### PR TITLE
Add new writing articles, fix newsletter UX, and fix sync script

### DIFF
--- a/scripts/sync-writing.mjs
+++ b/scripts/sync-writing.mjs
@@ -102,6 +102,7 @@ function serializeFrontmatter(fields) {
 
 function appendField(lines, key, val) {
   if (Array.isArray(val)) {
+    if (val.length === 0) return;
     const items = key === 'tags' ? val.map(displayTag) : val;
     lines.push(`${key}:`);
     for (const item of items) lines.push(`  - ${item}`);

--- a/src/content/writing/10-heuristics-to-simplify-design-decision-making.md
+++ b/src/content/writing/10-heuristics-to-simplify-design-decision-making.md
@@ -1,0 +1,212 @@
+---
+title: 10 Heuristics to Simplify Design Decision-Making
+description: How I use industry wisdom to guide my work and avoid the paradox of choice
+publishedDate: 2025-05-04
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/10-heuristics-to-simplify-design-d17"
+draft: false
+---
+Made by me with Midjourney.
+
+I designed a lot of software from scratch in the last decade.
+
+While I learned to navigate the seemingly endless decisions involved in this process over time, it’s never easy.
+
+The [paradox of choice](https://en.wikipedia.org/wiki/The_Paradox_of_Choice) can trap even the most seasoned practitioners.
+
+Thankfully, you can simplify the decision-making process by relying on a smart selection of industry wisdom.
+
+You do not have to, and should not, reinvent the wheel for many common problems.
+
+Instead, trust the expertise of those who came before you.
+
+Allow their findings to act as [heuristics](https://www.investopedia.com/terms/h/heuristics.asp), or rules of thumb, for navigating the complexity.
+
+As a veteran creative, I’ve internalized these principles through years of practice.
+
+However, I still reference them often to guide clients and colleagues toward making better and more confident design decisions.
+
+There are far too many useful heuristics to roll into a single article, so today I want to highlight 10 I return to frequently.
+
+---
+
+## The Heuristics
+
+### 1\. Jakob’s Law
+
+> "Users spend most of their time on other sites. This means that users prefer your site to work the same way as all the other sites they already know.” - [Jakob Nielsen](https://www.nngroup.com/people/jakob-nielsen/)
+
+#### About
+
+[Jakob's Law](https://www.nngroup.com/videos/jakobs-law-internet-ux/#:~:text=Summary%3A%20Users%20spend%20most%20of,other%20sites%20they%20already%20know.) emphasizes leveraging users' familiarity and expectations to create intuitive, user-friendly interfaces.
+
+#### How I use it
+
+I use Jakob’s Law to counteract the tendency to think that products are special snowflakes.
+
+It’s easy for product builders and entrepreneurs to lose touch with the fact that the product they’re working on isn’t the center of everyone’s universe (like it is for them). It’s one of many things competing for people’s attention in today’s digital landscape.
+
+Familiarity benefits the creator and the customer and sets the stage to break expectations intentionally for maximum impact.
+
+---
+
+### 2\. MAYA Rule
+
+#### About
+
+[Raymond Loewy](https://www.britannica.com/biography/Raymond-Loewy) ’s [MAYA Rule](https://www.interaction-design.org/literature/article/design-for-the-future-but-balance-it-with-your-users-present) (Most Advanced, Yet Acceptable) argues for designs that push the envelope in product innovation while remaining familiar and acceptable to users.
+
+#### How I use it
+
+If you’ve followed my writing for a while, you know I’m fond of the MAYA rule. It’s my guiding light for sticking the landing with design innovation.
+
+Depending on where a product sits on the spectrum of ‘acceptable’ to ‘advanced’, I can use design techniques to strategically nudge it into balance and deliver an experience that hits the sweet spot between novelty and familiarity.
+
+I wrote a full article about MAYA here -> [The Enduring Power of the MAYA Rule](https://www.unknownarts.co/p/the-maya-rule-for-design-impact)
+
+---
+
+### 3\. “Don’t make me think”
+
+#### About
+
+Steve Krug's " [Don't Make Me Think](https://sensible.com/dont-make-me-think/) " is a self-explanatory heuristic emphasizing the importance of creating self-explanatory interfaces.
+
+*Creating* an interface requires a lot of deep thought. *Using* an interface shouldn’t.
+
+#### How I use it
+
+I use “Don’t Make Me Think” as a first line of defense for usability.
+
+I accept that I’ll never remove all complexity from a system.
+
+But if I notice myself *thinking* more about the software rather than *doing* whatever it helps me do, it indicates I have room for improvement.
+
+---
+
+### 4\. Gaiman’s Law
+
+> “Remember: when people tell you something’s wrong or doesn’t work for them, they are almost always right. When they tell you exactly what they think is wrong and how to fix it, they are almost always wrong.” - [Neil Gaiman](https://www.neilgaiman.com/)
+
+#### About
+
+Gaiman’s Law suggests that users are good at identifying problems but bad at proposing effective solutions. It encourages us to seek insights from user feedback while relying on our expertise to interpret it and find the best solutions.
+
+#### How I use it
+
+I use Gaiman’s Law to help clients and colleagues get past the surface value of user feedback. This can be challenging when people are eager to please their customers (a good instinct that can go awry). Gaiman’s Law is a useful reminder that helps me avoid sacrificing the best creative output for immediate validation.
+
+---
+
+### 5\. Miller’s Law
+
+> “The average person can only keep 7 (plus or minus 2) items in their working memory.” - [George Miller](https://en.wikipedia.org/wiki/George_Armitage_Miller)
+
+#### About
+
+Miller’s Law guides us toward creating experiences that align with the cognitive constraints of users. Designing with its limitations in mind helps us present information and choices to users within a manageable range.
+
+#### How I use it
+
+I use Miller’s Law to find a balance between respecting a user’s intelligence and honoring the inherent limitations of being human. It prompts me to separate information into more digestible and memorable chunks which makes my work more accessible.
+
+For me, it’s less about the specific number 7 (though that is a useful guide) and more about ensuring a usable balance in my creations.
+
+---
+
+### 6\. “Default it or design it”
+
+#### About
+
+“Default it or design it” reminds us to consciously choose between default or custom elements to create interfaces that strategically leverage a company’s strengths and resources.
+
+#### How I use it
+
+I use this to force myself to prioritize when creating new UI.
+
+Every decision to build UI involves trade-offs. The best companies make deliberate moves when deciding what they should build from scratch and what they should ‘default’ to an existing solution.
+
+Here’s my article talking more about this -> [Default It of Design It](https://www.unknownarts.co/p/default-it-or-design-it)
+
+---
+
+### 7\. Conway’s Law
+
+> "Organizations which design systems... are constrained to produce designs which are copies of the communication structures of these organizations." - [Melvin Conway](https://en.wikipedia.org/wiki/Conway%27s_law)
+
+#### About
+
+Conway's Law describes the correlation between the structure of an organization and the design of the systems it produces.
+
+#### How I use it
+
+Over the last 12 years, I’ve seen this principle manifest repeatedly. As a creative leader and consultant, it reminds me that the final product is always downstream from the organization. Every employee and team can have good intentions, but if the organization is poorly designed its output will be too.
+
+---
+
+### 8\. Tesler’s Law
+
+> “For any system, there is a certain amount of complexity that cannot be reduced.” - [Larry Tesler](https://en.wikipedia.org/wiki/Larry_Tesler)
+
+#### About
+
+Tesler’s Law (also called The Law of Conservation of Complexity) reminds us that simplification efforts have limits.
+
+#### How I use it
+
+I use Tesler’s Law to counteract the tendency to want to oversimplify.
+
+Reducing designs to their essence is powerful but it’s easy to go too far in that pursuit. Rather than attempting to remove all complexity (which is impossible), this heuristic helps me aim to make it manageable.
+
+---
+
+### 9\. “To emphasize something, first deemphasize everything else.”
+
+#### About
+
+This principle stresses the importance of focus for clear communication and guiding users’ attention.
+
+#### How I use it
+
+I use this heuristic to help teams avoid the emphasis “arms race”.
+
+Teams without design guidance tend to emphasize new things by making each one louder than the last. This quickly becomes a death spiral of attention-grabbing that leads to confusion. When everything is “important,” nothing is.
+
+By starting from a place of de-emphasis, we give ourselves space to draw attention to what truly matters.
+
+---
+
+### 10\. Doherty Threshold
+
+> “Productivity soars when a computer and its users interact at a pace (<400ms) that ensures that neither has to wait on the other.” - [Laws of UX](https://lawsofux.com/doherty-threshold/)
+
+#### About
+
+The Doherty Threshold highlights the importance of performance for crafting software that feels good to use. It reminds us that we can control how the software *feels* by dialing in the interaction times.
+
+#### How I use it
+
+I use this principle in two ways:
+
+First, it’s a good motivator for boosting the speed of your data systems. Processing data faster is rarely a bad thing in software.
+
+Second, it helps me craft interactions that smooth out the technical performance. If the data speeds are slower, I can introduce elements that create the perception that the software is working quickly. If the speed is instant, I can introduce elements that slow it down to make it feel less jarring.
+
+---
+
+## Final Thoughts
+
+The ten heuristics I've outlined have been useful in my journey.
+
+They offered me practical advice, steering me toward effective design choices.
+
+As you incorporate them into your work, it's important to see them not as rigid rules but as flexible tools.
+
+Let them inform your decisions, but not constrain your creativity.
+
+Until next time,
+
+Patrick
+
+> *What heuristics have you returned to the most in your career?*

--- a/src/content/writing/3-models-for-framing-software-complexity.md
+++ b/src/content/writing/3-models-for-framing-software-complexity.md
@@ -1,0 +1,83 @@
+---
+title: 3 Models for Framing Software Complexity
+description: "Using 37 Signals' visual metaphors to strategically approach software projects"
+publishedDate: 2024-04-21
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/3-models-for-framing-software-complexity"
+draft: false
+---
+Made with Midjourney
+
+The complexity of software is often hidden and abstract, making it hard to develop a sense of the scope of work implied by a design.
+
+This skill is hard-earned - it's a mix of foundational knowledge about software structure and years of experience learning how certain projects surface specific problems.
+
+Engineers naturally develop this muscle through the process of working in the codebase. But designers and product managers don't confront the complexity in the same way, making it harder for them to build this instinct.
+
+No matter your role, your team will benefit from getting better at identifying complexity early, discussing it clearly, and making smart trade-offs to scope projects. A quick gut check on where the bulk of the complexity lies can do wonders for setting realistic design constraints before committing to any direction or timeline.
+
+My favorite metaphor for framing software complexity comes from the team at [37 Signals](https://37signals.com/). Their simple, visual breakdown captures the essence of what I learned during my time as a software engineer. It's helped me approach projects more strategically and communicate more clearly with my teams.
+
+With that context in mind, let's dive into the first of their three models - the Layer Cake distribution.
+
+Source: 37 Signals, Shape Up - Chapter 12
+
+## 1\. Layer Cake
+
+In a layer cake, the complexity is spread evenly across the front end and back end. An even distribution doesn't mean an easy project - it just means the relative weight of the complexity demands equal attention on both sides.
+
+E-commerce platforms tend to exhibit a layer cake-like complexity distribution:
+
+- **Front-End**: The interface needs to be intuitive and engaging. You need to handle product displays, user interactions like cart management, checkout flows, and ensure a responsive design across various devices.
+- **Back-End**: There's complexity in wrangling inventory management, integrating with payment gateways, handling user data, managing order history, and more.
+
+There's plenty of complexity on both sides, but weighted similarly. A layer cake project needs a balanced team working in unison from initial design through final development.
+
+Next up is a distribution that catches many designers off-guard - the Back-End Iceberg.
+
+Source: 37 Signals, Shape Up - Chapter 12
+
+## 2\. Back End Iceberg
+
+In a back-end iceberg, the majority of the complexity is hidden from view. These projects can be tricky for designers to approach, as a seemingly simple interface may be deceptively difficult to implement behind the scenes.
+
+I encountered many back-end icebergs during my time designing cybersecurity and data platform companies. For instance, consider creating a machine-learning platform:
+
+- **Front-End**: The interface might be straightforward, aimed at allowing users to upload datasets, initiate training models, and view basic analytics about model performance.
+- **Back-End**: Behind the scenes, you have to wrangle large datasets, run data processing pipelines, manage model training and deployment, ensure the scalability of operations, and potentially integrate with multiple other systems.
+
+Heavy back-end complexity requires an engineering-centric team. While designers and developers should still collaborate throughout the project, the lighter load on the designer might free them up to work on additional projects while the engineering team tackles the back-end challenges. Design engineers can act as valuable intermediaries in these situations, helping designers understand the hidden complexity and assisting back-end engineers with prototyping basic UIs before committing to a final design.
+
+Just as back-end complexity can be obscured, the inverse is also true. Let's look at the Front-End Iceberg, where the user interface holds the technical challenges.
+
+Source: 37 Signals, Shape Up - Chapter 12
+
+## 3\. Front End Iceberg
+
+In a front-end iceberg, most of the complexity accumulates in the user interface itself. This visual complexity can deceive you into thinking the back-end is equally challenging, potentially leading to a misallocation of resources.
+
+The main place I encountered front-end icebergs was with data visualization and dashboard projects:
+
+- **Front-End**: The primary challenge lies in presenting complex data in a user-friendly manner. This involves advanced UI components, intricate interactions, customizable views, and more. There's a lot of design nuance required to get it right.
+- **Back-End**: While still important, the back-end work might be more straightforward, focused primarily on data retrieval, basic processing, and serving the API endpoints for the front-end to consume.
+
+Heavy front-end complexity demands more design-centric teams. With minimal required back-end development involvement, the focus shifts to close collaboration between front-end developers and designers.
+
+This is another area where design engineers can shine. In-browser UI prototyping plays a crucial role in ensuring the interaction design works seamlessly in a highly stateful environment. Rapidly cycling through iterations - from sketches to code prototypes to polished UI - helps smooth out the overall user experience.
+
+## Final Thoughts
+
+Whichever metaphor best captures your project's reality, the key is being intentional about surfacing and discussing complexity upfront.
+
+This model of layer cakes, back-end icebergs, and front-end icebergs has been invaluable for me in navigating software projects over the years. It's helped me assemble the right teams, allocate resources, and guide design work more strategically.
+
+Versatile roles like design engineers were critical for bridging gaps and facilitating collaboration across disciplines. Their involvement smoothed the process immensely.
+
+Ultimately, this complexity-conscious approach empowered my teams to make well-informed choices, mitigating risks and driving high-quality outcomes. It allowed us to confront stumbling blocks head-on rather than being caught off guard down the line.
+
+I hope unpacking complexity using these models can be as valuable to you as it has been for me. The ability to explicitly frame and discuss it is a game-changer for undertaking any software project with clarity and confidence.
+
+Until next time,
+
+Patrick

--- a/src/content/writing/5-proven-sets-of-design-principles-and-how-i-use-them.md
+++ b/src/content/writing/5-proven-sets-of-design-principles-and-how-i-use-them.md
@@ -1,0 +1,218 @@
+---
+title: 5 Proven Sets of Design Principles and How I Use Them
+description: Tried and true guidelines for crafting great quality, high impact designs
+publishedDate: 2023-08-20
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/5-proven-sets-of-design-principles"
+draft: false
+---
+Made with Midjourney
+
+## Intro
+
+Articulating why a design is *good* is always a challenge.
+
+Even the veterans sometimes struggle to find the words!
+
+Luckily, there are a number of common sets of design principles that provide practical starting points for analyzing designs and expressing what’s successful or unsuccessful about them.
+
+While senior designers tend to internalize these principles through years of practice, for everyone else, it’s helpful to have a quick reference you can open up when it’s time to review. This post is meant to provide that reference.
+
+It’s important to note that design principles are not immutable laws of nature; they’re rules of thumb that *tend* to result in better work.
+
+Think of them as suggestions from a trusted mentor: you should probably take their advice, at least until you’re very confident in your own skills and experience.
+
+The following five sets of principles are the ones I’ve turned to the most in my decade of creating digital products. They aren’t a silver bullet for every scenario you’ll face, but they’re tried and true and have been useful for me.
+
+I hope you find them useful too.
+
+Until next time,
+
+Patrick
+
+---
+
+Source: OnlyOnceShop
+
+## 1\. Dieter Rams’ 10 principles for good design
+
+### Overview
+
+Industrial designer Dieter Rams was concerned about the poorly designed and unnecessary products that he saw on the rise during the latter half of the 20th century. By capturing his 10 principles, Rams aimed to offer clear guidelines that designers could follow to make their work more effective, responsible, and enduring.
+
+### How I use them
+
+Rams’ principles are great for discussing why a design works or doesn’t work at a high level.
+
+I find them particularly useful for making product design analysis approachable for anyone in business (which is why I use them routinely in my articles! 😇).
+
+Few products nail every principle, but if you let one lead the way and build up a couple of others as support, you’re likely headed toward a good design.
+
+### The principles
+
+1. Good design is innovative
+2. Good design makes a product useful
+3. Good design is aesthetic
+4. Good design makes a product understandable
+5. Good design is unobtrusive
+6. Good design is honest
+7. Good design is long-lasting
+8. Good design is thorough down to the last detail
+9. Good design is environmentally friendly
+10. Good design is as little design as possible
+
+### Resources
+
+- Article → ["Dieter Rams: Ten Principles for Good Design" - Vitsoe](https://www.vitsoe.com/us/about/good-design)
+- Film → [Documentary: "Rams" by Gary Hustwit (2018)](https://www.hustwit.com/rams/)
+- Better by Design articles highlighting aspects of each principle:
+	- Principle 1 → [Anglepoise lamp](https://www.betterbydesign.cc/p/taste-of-quality-20-the-anglepoise?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 2 → [Dyson cordless vacuum](https://www.betterbydesign.cc/p/design-gratitude-11-dyson-cordless?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 3 → [Eames shell chair](https://www.betterbydesign.cc/p/taste-of-quality-22-eames-dining?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 4 → [Vitamix blender](https://www.betterbydesign.cc/p/design-gratitude-19-the-vitamix-blender?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 5 → [Motorola Razr v3](https://www.betterbydesign.cc/p/design-gratitude-12-motorola-razr?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 6 → [Converse All-Stars](https://www.betterbydesign.cc/p/design-gratitude-9-converse-all-stars?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 7 → [The gooseneck kettle](https://www.betterbydesign.cc/p/the-gooseneck-kettle?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 8 → [Stardew Valley](https://www.betterbydesign.cc/p/design-gratitude-17-stardew-valley?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 9 → [Dr. Bronner’s soaps](https://www.betterbydesign.cc/p/design-gratitude-18-dr-bronners-soaps?r=oqbs9&utm_campaign=post&utm_medium=web)
+	- Principle 10 → [The pedestal collection](https://www.betterbydesign.cc/p/design-gratitude-7-the-pedestal-collection?r=oqbs9&utm_campaign=post&utm_medium=web)
+
+---
+
+Source: Michal Langmajer
+
+## 2\. Nielsen-Norman usability heuristics
+
+### Overview
+
+Rooted in decades of user experience research, the Nielsen-Norman heuristics offer a good reference for creating intuitive and user-friendly digital interfaces.
+
+### How I use them
+
+I use the Nielsen-Norman heuristics as a first line of defense for sticking the landing with interface usability.
+
+When I’m new to a product it can be helpful to use them as a foundation for auditing how the experience might be improved.
+
+I also find them useful for guiding software engineers toward making smarter user experience decisions even in the absence of much direct design support.
+
+Ultimately, if your software holds up well against these heuristics, you’re probably doing pretty well for yourself.
+
+### The principles
+
+1. Visibility of system status
+2. Match between the system and the real world
+3. User control and freedom
+4. Consistency and standards
+5. Error prevention
+6. Recognition rather than recall
+7. Flexibility and efficiency of use
+8. Aesthetic and minimalist design
+9. Help users recognize, diagnose, and recover from errors
+10. Help and documentation
+
+### Resources
+
+- Article → [10 Usability Heuristics for User Interface Design](https://www.nngroup.com/articles/ten-usability-heuristics)
+- Article → [How to Conduct a Heuristic Evaluation](https://www.nngroup.com/articles/how-to-conduct-a-heuristic-evaluation/)
+- Examples of the 10 usability heuristics applied to…
+	- [Complex Applications](https://www.nngroup.com/articles/usability-heuristics-complex-applications/)
+	- [Virtual Reality](https://www.nngroup.com/articles/usability-heuristics-virtual-reality/)
+	- [Video Games](https://www.nngroup.com/articles/usability-heuristics-applied-video-games/)
+
+---
+
+Source: Straive
+
+## 3\. W3C accessibility principles
+
+### Overview
+
+A cornerstone of inclusive design, the W3C accessibility principles emphasize the importance of creating digital products that work for every user, regardless of ability or impairment.
+
+### How I use them
+
+I find the W3C principles to be most useful when I’m trying to communicate tangible reasons why to prefer one design execution over another.
+
+Particularly in environments where I’m either the only designer or one of few, being able to tie visual design executions to compliance standards gives me more support to back up design choices that may otherwise be seen as purely qualitative.
+
+### The principles
+
+1. **Perceivable:** Information and user interface components must be presented in ways all users can perceive.
+2. **Operable:** Users must be able to interact and navigate easily.
+3. **Understandable:** Information and the operation of the user interface must be clear.
+4. **Robust:** Content must be robust enough to be interpreted by a wide variety of user agents, including assistive technologies.
+
+### Resources
+
+- Docs → [W3C Principles Official Docs](https://www.w3.org/WAI/fundamentals/accessibility-principles)
+
+---
+
+Source: Toptal
+
+## 4\. Gestalt principles
+
+### Overview
+
+Delving into the psychology of perception, the Gestalt principles help designers understand how humans interpret visual information, ensuring that digital interfaces align with innate cognitive patterns.
+
+### How I use them
+
+I reference Gestalt principles when I need to get specific about visual design.
+
+By aligning my work with natural human perception, Gestalt principles help me to make interfaces that are more intuitive and approachable. They give me clear levers I can pull to guide my audience’s focus.
+
+These are the most scientific and objective of the principles included in this post, so they’re worth a little extra attention.
+
+### The principles
+
+1. **Proximity:** Objects close to each other are perceived as a group.
+2. **Similarity:** Similar objects are often seen as a group.
+3. **Continuity:** The eye is drawn to continuous lines and shapes.
+4. **Closure:** We tend to see complete figures even when part of the information is missing.
+5. **Figure-ground:** We distinguish between a figure (object of focus) and its surrounding background.
+6. **Common Fate:** Elements moving in the same direction or displaying similar motion are perceived to be more related than those that are stationary or move in different directions.
+7. **Symmetry & Order:** People will perceive and interpret ambiguous or complex images in the simplest form possible.
+
+### Resources
+
+- Article → [Exploring the Gestalt Principles of Design](https://www.toptal.com/designers/ui/gestalt-principles-of-design#:~:text=The%20classic%20principles%20of%20the,\(also%20known%20as%20pr%C3%A4gnanz\).)
+- Article → [Improve Your Designs With The Principles Of Similarity And Proximity](https://www.smashingmagazine.com/2016/05/improve-your-designs-with-principles-similarity-proximity-part-1/)
+- Article → [Improve Your Designs With The Principles Of Closure And Figure-Ground](https://www.smashingmagazine.com/2016/05/improve-your-designs-with-the-principles-of-closure-and-figure-ground-part-2/)
+
+---
+
+Source: Center for Humane Technology
+
+## 5\. Tenets of Humane Technology
+
+### Overview
+
+The [Center for Humane Technology](https://www.humanetech.com/) ’s tenets are an important new set of guidelines for modern product creators.
+
+They push technologists to think beyond engagement metrics and prioritize genuine human well-being.
+
+They leave behind the era of “move fast and break things”, ushering in a future where technology works with, rather than against, our human nature.
+
+### How I use them
+
+I use these principles as a guide for considering the ethical impact of choices I make when creating new technologies. They may be lofty, but they’re worth striving for.
+
+### The principles
+
+1. **Respect human nature:** ”How can technology work with, rather than against, our innate vulnerabilities and biases?”
+2. **Minimize harmful externalities:** “How do economic forces affect products, and how can product teams reduce harmful side effects?”
+3. **Center on values:** “How do the conditions of our lives shape our values and how might metric-driven product development be centered on our values?”
+4. **Create shared understanding:** “How can technology foster the trust and understanding we need to solve complex problems together?”
+5. **Support fairness and justice:** “How can technology enable a more just world, and integrate the voices of people who experience harm?”
+6. **Help people thrive:** “How can products help people act in alignment with their deeper intentions, rather than optimizing for engagement?”
+
+### Resources
+
+- Website → [Center for Humane Technology](https://www.humanetech.com/)
+- Course → [Humane Tech Course](https://www.humanetech.com/course)
+- Video → [The Social Dilemma](https://www.humanetech.com/the-social-dilemma)
+- Person → [Tristan Harris](https://www.tristanharris.com/)
+
+> *Interested in working together? Check out [my portfolio](https://patrickmorgan.org/).*

--- a/src/content/writing/7-insights-for-navigating-b2b-design.md
+++ b/src/content/writing/7-insights-for-navigating-b2b-design.md
@@ -1,0 +1,169 @@
+---
+title: 7 Insights for Navigating B2B Design
+description: Key dynamics I wish I had known sooner in my enterprise design career.
+publishedDate: 2024-03-03
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/7-insights-for-navigating-b2b-design"
+draft: false
+---
+Made by me with Midjourney.
+
+Shifting from B2C to B2B software design isn't just a change of audience — it's a whole new playing field.
+
+Today I’ll expand on [my reply to Linear CEO Karri Saarinen’s post](https://twitter.com/itspatmorgan/status/1763655052206711092) on this topic and highlight 7 key insights that helped me navigate the shift in my career.
+
+In the last 7 years, [I designed 3 separate 9 & 10-figure cybersecurity startups](https://www.linkedin.com/in/itspatmorgan/).
+
+After spending the early years of my career focused on consumer-facing products, I was surprised to discover the differences in B2B.
+
+B2B design differs from B2C but gets little attention from the design community.
+
+It’s sad, but it makes sense.
+
+B2B software isn’t a sexy topic ripe for social media shares.
+
+The brands aren’t names your family will recognize.
+
+And the aesthetics won’t excite designers like flashy new consumer tech.
+
+That said, B2B software is incredibly high leverage when well-executed.
+
+This makes good B2B software as good as gold and the companies that create it very valuable. It also makes the jobs they offer quite lucrative.
+
+The B2B SaaS work environment differs from what many designers expect, but I think it’s worth their attention. It’s an area ripe for design disruption with the right mindset and culture shifts. Let’s be real, the design quality bar in this space is low. But this makes the impact of good design that much more significant and far-reaching.
+
+Now let’s dig into a few key insights that helped me navigate this landscape.
+
+## Key Insights
+
+### 1\. Frontstage vs. Backstage Customer Service
+
+B2B organizations look different than B2C ones.
+
+In particular, they have large departments dedicated to customer service beyond basic support staff. These teams go by many names, but the ones I’ve encountered the most are ‘ *professional services* ’, ‘ *solutions architecture* ’, ‘ *account management* ’, and ‘ *customer success*.’ The people in these roles are in constant contact with users and it’s their full-time job to understand their needs, represent them, and help them succeed.
+
+This opens a lot of options for how to solve customer problems. It’s like layering a service business on top of a software business.
+
+Frontstage vs. Backstage is a [Service Design](https://www.nngroup.com/articles/service-design-101/) metaphor that helps make sense of the many actions that serve a customer across all the touchpoints in an enterprise.
+
+In this context:
+
+- **Frontstage** \= Things that happen in direct view of the customer
+	- These could be interactions between the customer and the software or the customer and an employee.
+- **Backstage** \= Things that happen behind the scenes to support frontstage actions
+	- This includes everything the team does to deliver the software and anything a team member does on behalf of the customer without their presence.
+
+In this context, shipping new software to the customer isn’t always the best way to solve their problem. Sometimes a frontstage employee can handle it manually. Other times creating an internal tool to help frontstage colleagues serve the customer will make a bigger impact. Ultimately, you can create systems and software to facilitate any frontstage process, whether it’s led by the customer or by an employee on their behalf.
+
+Frontstage and backstage need to work together to deliver a great user experience but it can be tricky because there’s a lot to coordinate. I like to capture these collaborative workflows in [Service Blueprints](https://www.nngroup.com/articles/service-blueprints-definition/), which you can think of as a [user journey](https://www.nngroup.com/articles/journey-mapping-101/) with an added dimension that maps your organization and services onto the user’s journey to visualize how you deliver on their needs from end to end.
+
+### 2\. The User vs. The Buyer
+
+In consumer software, the person who buys the product tends to be the one who uses it.
+
+This isn’t the case in enterprise software.
+
+In this context, the person who makes the purchase decision (the buyer) is often different from the person who uses the software daily for their work (the user).
+
+An example from my cybersecurity career:
+
+- *Security engineers* **used** our software.
+- *Chief Security Officers* **bought** our software.
+
+In practice, that meant that I designed mostly for the security engineer (the user) but needed to deliver enough value to the Chief Security Officer (the buyer) for them to decide to sign the contract. That’s no small feat when contracts range in the hundreds of thousands or millions of dollars per year.
+
+Be careful not to neglect either one of these personas. Designers gravitate toward the user, but if you neglect the buyer then your product will struggle to sell. On the flip side, salespeople gravitate toward the buyer, but if you neglect the user then your software will struggle to retain and upsell when it comes time to renew the contract.
+
+There are also sometimes third parties (neither the user nor the buyer) who can torpedo the sales process. For instance, a CTO who refuses to integrate your service in their tech stack no matter how good your solution is.
+
+### 3\. Long-term Relationships with Clients
+
+Enterprise software often involves long-term client relationships.
+
+Contracts tend to be measured in years, not months.
+
+These extended relationships are a blessing for design because they open the door for more consistent and transparent feedback. The best ones evolve into a kind of mutually beneficial partnership that makes each business stronger.
+
+These clients see the value in your software and want to help you improve your product so they can do their business better.
+
+Rather than having to rely on macro-level consumer data to inform design decisions, you can talk directly with customers who are invested in helping you succeed.
+
+Leaning into the collaborative process of designing and building ***with*** your customers rather than just ***for*** them can unlock great results.
+
+It’s pretty much the definition of “win-win.”
+
+### 4\. Different "Voices of the Customer"
+
+As a junior designer, I was taught that design should be the “voice of the customer.”
+
+However, at my B2B startups, there were even stronger customer advocates already inside the company. These are the frontstage departments I mentioned earlier.
+
+While it felt unnatural at first, I learned to loosen my grip on the idea that I needed to be the primary “voice of the customer” to make a difference with design.
+
+Instead, I shifted my focus to interpreting the constant flow of feedback coming to my colleagues and synthesizing it into smarter design choices for the product.
+
+Establishing the customer feedback loop from frontstage teams to design opens the product design flywheel. B2B companies have the gift of continuous feedback. Don’t waste it just because you’re hung up on the idea that only design can represent the customer’s needs.
+
+### 5\. Qualitative data > Quantitative data
+
+Quantitative data can be harder to come by in a B2B context because the number of users tends to be much smaller than B2C. You’re likely working with tens or hundreds of customers rather than thousands or millions.
+
+In my career at enterprise startups, I never had the user scale to get quantitative results fast enough to routinely inform my choices.
+
+This meant some methodologies (like [A/B testing](https://www.nngroup.com/videos/ab-testing-101/), for instance) weren’t useful.
+
+Instead, this environment prioritized a combination of qualitative research and craft to make design decisions.
+
+As I mentioned earlier, B2B environments are rich with qualitative feedback coming directly from customers.
+
+This makes them a surprisingly good place for designers to flex their skills, which tend to be grounded in qualitative methods.
+
+### 6\. Compliance Requirements
+
+Enterprise software has stricter requirements for security, compliance, and accessibility.
+
+Highly regulated industries like finance, healthcare, or the government stand out as obvious examples.
+
+No matter how you slice it, compliance requirements introduce more complexity to any design project. However, if you plan accordingly you can make strategic design decisions to minimize the impact and handle compliance gracefully.
+
+Compliance requirements can manifest in a bunch of ways:
+
+- Content requirements like legal copy
+- Technical requirements like data privacy protections
+- Design requirements like accessibility standards
+- And so on…
+
+These can be real challenges for crafting a thoughtful and aesthetic interface.
+
+However, if you accept these as inevitable and create your UI with flexibility and resilience in mind they don’t have to destroy your design hopes and dreams.
+
+You might not get the full version of your ideal design, but you don’t have to ship a scary Frankenstein either. I promise.
+
+### 7\. High Stakes Changes
+
+The stakes of making changes in B2B software can be very high.
+
+Mistakes can cost *millions* of dollars.
+
+Screwing up another business’ operations can cause them real financial harm. Meanwhile, losing a single, valuable enterprise customer can be a big hit to your company’s bottom line.
+
+For example, when I was designing the firewall configuration experience at [Signal Sciences / Fastly](https://www.fastly.com/products/web-application-api-protection), shipping a poor experience could result in an error that would take down our systems, our customers’ systems, and the other businesses that depended on them. Trust me, you don’t wanna be on the receiving end of that phone call.
+
+So in B2B, teams need to respect the high-stakes nature of the changes they ship. They must ensure the software is robust and performs well under a wide range of conditions. While designers may not push the code to production or be on-call to resolve an outage, we owe it to our teammates to “ [measure twice, cut once](https://rksdesign.com/measure-twice-cut-once/) ” and be deliberate in our approach to prototyping and rollout.
+
+## Final Thoughts
+
+B2B design is rich with challenges but even richer with opportunities.
+
+By understanding the unique landscape of B2B — from company dynamics to customer interaction — we can create designs that aren't just functional, but foundational to business success.
+
+So, as we wrap this up, think of it this way: your design can change how businesses work for the better. With your skills and my guidance, you can help make software that shapes industries and improves the lives of those who work in them.
+
+Here's to making work life better for everyone with great design.
+
+Until next time,
+
+Patrick
+
+---

--- a/src/content/writing/8-design-breakthroughs-defining-ais-future.md
+++ b/src/content/writing/8-design-breakthroughs-defining-ais-future.md
@@ -1,0 +1,168 @@
+---
+title: "8 Design Breakthroughs Defining AI's Future"
+description: How key interface decisions are shaping the next era of human-computer interaction
+publishedDate: 2025-02-02
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/8-design-breakthroughs-defining-ais"
+draft: false
+---
+Made with Midjourney.
+
+Interface designers are navigating uncharted territory.
+
+For the first time in over a decade, we're facing a truly greenfield space in user experience design. There's no playbook, no established patterns to fall back on. Even the frontier AI labs are learning through experimentation, watching to see what resonates as they introduce new ways to interact.
+
+This moment reminds me of the dawn of touch-based mobile interfaces, when designers were actively inventing the interaction patterns we now take for granted. Just as those early iOS and Android design choices shaped an era of mobile computing, today's breakthroughs are defining how we'll collaborate with AI for years to come.
+
+It’s fascinating to watch these design choices ripple across the ecosystem in real-time. When something works, competitors rush to adopt it - not out of laziness, but because we're all collectively discovering what makes sense in this new paradigm.
+
+In this wild-west moment, new dominant patterns are emerging. Today, I want to highlight the breakthroughs that have captured my imagination the most - the design choices shaping our collective understanding of AI interaction. Some of these are obvious now, but each represented a crucial moment of discovery, a successful experiment that helped us better understand how humans and AI might work together.
+
+By studying these influential patterns, we can move beyond copying what works to shaping where AI interfaces go next.
+
+---
+
+## The Breakthroughs
+
+Early ChatGPT on top. The dev playground that preceded it below.
+
+### 1\. The Conversational Paradigm (ChatGPT)
+
+> **Key Insight:** Humans already know how to express complex ideas through conversation - why make them learn something else?
+> 
+> **Impact:** Established conversation as the fundamental paradigm for human-AI interaction
+
+The chat interface is so ubiquitous now we barely think about it, but it's the breakthrough that launched us into our current era. GPT had already been available in OpenAI’s developer console, but that interface didn't resonate with a wide audience. It looked and felt more like any other dev tool. I remember playing around with it and being impressed, but it didn't capture my imagination.
+
+The decision to shift that underlying technology into a conversational format made all the difference. What's interesting is how little the company itself probably thought of this change. I mean, they named it *ChatGPT* for crying out loud—not exactly the brand name you'd pick if you thought you were making a revolutionary consumer product. But it proved to be the single most important design choice of this generation. The chat interface has since been copied far and wide, influencing virtually every consumer AI tool that followed.
+
+I used to think that the chat interface would eventually fade, but I don’t anymore. This entire wave of generative AI tools is built around natural language at the core and conversation is the central mechanic for sharing ideas with language. Clunky chatbots will evolve, but conversation will persist as a foundational paradigm.
+
+---
+
+While minimal in terms of UI, citations were a big step.
+
+### 2\. Source Transparency (Perplexity)
+
+> **Key Insight:** Without seeing sources, users can't validate AI responses for research
+> 
+> **Impact:** Set new expectations for verifiable AI outputs in search and research tools
+
+Once people started using ChatGPT frequently, common complaints emerged around the lack of sources. While GPT could generate responses based on its massive training data, there was no way to understand where that information came from, making it difficult to use for legitimate research.
+
+Perplexity changed the game by introducing real-time citations for its AI responses, making its answers traceable and verifiable. This feature has since been heavily copied, including by OpenAI with its web search integration in ChatGPT. It addressed a fundamental trust issue: users wanted not just answers, but confidence in where those answers came from.
+
+This breakthrough was essential for addressing people’s concerns about using AI as a new form of search engine, but the reality is that AI does much more. LLMs can enhance question-answer style tools like Perplexity, but they also open the door to entirely new creative workflows.
+
+---
+
+Conversation drives creative outputs with Artifacts
+
+### 3\. Creative Integration (Claude Artifacts)
+
+> **Key Insight:** Conversation can do more than generate text - it can drive the creation of structured, reusable assets
+> 
+> **Impact:** Enabled new creative workflows where dialogue produces tangible outputs
+
+Using artifacts was the first time I felt like I was actively creating something with AI rather than just having a conversation. My previous chats with ChatGPT and Claude had been valuable for ideation, and Perplexity had been useful for research, but artifacts gave me that 'a-ha' moment—I could start my creative workflow with a conversation and translate the best parts into tangible outputs I could export and reuse later. We still have a ways to go to make it easy to continue your workflow after creating an asset with this dialogue-based interaction loop, but we’re moving in that direction.
+
+For me, Artifacts proved AI collaboration would be the core of a new creative workflow, shifting my expected interaction model: instead of AI being a supporting tool, the dialogue with Claude became the core mechanic, generating creative output we refined together. AI wasn’t just my 'assistant' or 'copilot'—it was increasingly in the driver's seat.
+
+---
+
+Dictation input on ChatGPT iOS app
+
+### 4\. Natural Interaction (Voice Input)
+
+> **Key Insight:** Speaking allows for richer, more natural expression compared to typing
+> 
+> **Impact:** Reduced friction for providing detailed context and exploring ideas with AI
+
+A lot of people are still overlooking voice as an input method. I think we have collective disbelief that it can work, thanks to a generation of mostly incompetent voice assistants (*I’m looking at you, Siri*). But the reality is that AI transcription is very good now.
+
+Voice input is crucial because it allows you to actually use natural language. We forget, but as soon as we go to write anything down, we start to edit ourselves. Speaking out loud allows your brain to tap into its full improvisational creativity. This output provides much richer context to the LLM—which is exactly what it thrives on. I think people get self-conscious or worry about seeing the messiness of real spoken language in text (all the umm's and ahh's, for instance). But I can tell you from experience that current LLMs don't care about that. They see past it and even filter out a lot of it.
+
+What you're left with is a much more natural creative ideation flow that gets captured and interpreted quickly and thoroughly by the AI. I'm very bullish on dictation as a central creative skill for the next generation. Start practicing it today because it does take some time to get used to if you're new to it like I was.
+
+---
+
+Deep integration into existing coding workflows is powerful
+
+### 5\. Workflow Integration (Cursor IDE)
+
+> **Key Insight:** Deeply embedding AI can supercharge where people already work
+> 
+> **Impact:** Transformed code editors into AI-powered creative environments
+
+Cursor brought the AI-led creative workflow I first experienced with Claude artifacts directly into the context of my existing codebases. Some of its features felt like no-brainers–' *of course an IDE should do this* ' kind of moments (like its powerful tab-to-complete feature).
+
+While I was a professional UI developer earlier in my career, I hadn't written code regularly for years until picking up Cursor. Getting back into it was always challenging because I'd get stuck on new syntax or unfamiliar framework features. Tools like Cursor help sidestep many of those blockers. For example, it can be overwhelming when you first open an existing codebase because you don't know what's available or where to find it. With Cursor, I can ask detailed questions about what’s going on and any code I’m unsure about and get answers quickly.
+
+Working with Cursor also reinforced for me how powerful it is to have AI reading and writing directly to your file system. My work with Claude is great, but always requires an additional step to get the output out of Claude and into whatever platform I want to pick it up with later. With tools like Cursor, the output is immediately available in its final destination which makes the workflow much tighter.
+
+---
+
+### 6\. Ambient Assistance (Grok Button on X)
+
+> **Key Insight:** Users need AI help most at the moment they encounter something they don't understand
+> 
+> **Impact:** Made contextual AI assistance instantly accessible alongside content
+
+The usefulness of the Grok button took me by surprise. There's so much content flowing through the X feed that I regularly feel like I don't have the right context to fully understand a given post. The direct integration of the Grok AI button at the content level gives me one-click context for real-time interpretation of the information I'm being bombarded with online. Whether it's a meme, an article headline, or anything else, it's very useful to be able to call upon the AI assistant to help me interpret what I'm seeing.
+
+I think this kind of assistance will become more important as the content we encounter online is increasingly up for interpretation (*is this AI generated? who published it? what are their biases? how are they trying to influence me?*).
+
+This is still new and, like many things in the X platform, the design execution leaves something to be desired. But I quickly found myself wishing for this kind of ambient 'give me more context' button on other sites I use around the web. Eventually, it feels like OS level assistants (Gemini, Siri, etc…) will deliver this functionality, but the Grok button is a good example of how valuable ambient assistance can be when integrated well.
+
+---
+
+DeepSeek shows the ‘thinking’ that leads to its response
+
+### 7\. Process Transparency (Deepseek)
+
+> **Key Insight:** Showing how AI reaches its conclusions builds user confidence and understanding
+> 
+> **Impact:** Humanized AI responses by making machine reasoning visible and relatable
+
+The most recent entrant to this list is Deepseek, which blew up the internet recently with the release of its R1 reasoning model. While it wasn't the first reasoning model to market, it made a critical design choice that fundamentally changed the experience for many people: it exposed the model's 'thinking'.
+
+This caught people's attention because it shows how the machine arrives at its answer, and the language it uses in its 'thoughts' looks an awful lot like what a person would say or feel. This visibility helps build trust in the output as users can verify whether the thought process makes sense. Another side effect is that there might be useful ideas in the reasoning itself—like maybe an idea that came up in the middle was interesting and worthy of further exploration on its own.
+
+It reminds me of the importance of progress bars in the last generation of web apps. If an interaction happens instantly, it can feel jarring. But if it happens slowly without any indication, people will wonder if it's working or broken. The progress bar helps smooth that out by helping users understand that the machine is working. Showing the AI's reasoning feels similar—it reinforces that the model is indeed working. Going forward, I don't think exposing model reasoning upfront will be necessary, but it should at least be clearly accessible so users can follow along if they choose.
+
+---
+
+Leveraging Discord’s UI meant Midjourney could postpone creating their own.
+
+### 8\. Interface Deferral (Midjourney)
+
+> **Key Insight:** Getting the core technology right matters more than having a polished interface
+> 
+> **Impact:** Demonstrated how focusing on capability first leads to better informed interface decisions
+
+So much of the design conversation focuses on visual interfaces that it makes Midjourney all the more interesting. The company’s choice to avoid building a custom UI in its early days and instead leverage Discord is fascinating and strategic. Even though Midjourney is a tool for visual creators, the company's core product is the tech that makes the visuals possible. That is the engine for everything else. If it wasn't excellent, people wouldn't care whether or not they had a web interface.
+
+While Midjourney now has a web UI, choosing to avoid custom UI initially allowed them to focus on the core capability of the model over the interface. Starting in Discord controlled the demand for the product by putting it in an environment where many people who weren't early adopters simply wouldn't go (*myself included*). It also provided super-powered community-based feedback loops that enabled highly informed product decision-making.
+
+So, depending on the kind of AI you’re creating, Midjourney serves as a reminder that choosing not to build a custom UI can itself be a strategic design choice.
+
+---
+
+## Final Thoughts
+
+These eight breakthroughs aren't just clever UI decisions—they're the first chapters in a new story about how humans and machines work together. Each represents a moment when someone dared to experiment, to try something unproven, and found a pattern that resonated.
+
+From ChatGPT making AI feel conversational, to Claude turning dialogue into creation, to Deepseek showing us how machines think—we're watching the rapid evolution of a new creative medium. Even Midjourney's choice to avoid building a custom UI reminds us that everything we thought we knew about software design is up for reinterpretation.
+
+The pace of innovation isn't slowing down. If anything, it's accelerating. But that's what makes this moment so exciting: we're not just observers, we're participants. Every designer, developer, and creator working with AI today has the chance to contribute to this emerging language of human-AI interaction.
+
+The initial building blocks are on the table. The question isn't just "What will you build with them?" but "What new blocks and patterns will you discover?"
+
+I'd love to hear which breakthroughs have captured your imagination or what patterns you're seeing emerge. Your insights might just shape the next chapter of this story.
+
+Until next time,
+
+Patrick
+
+> *Interested in working together? Check out [my portfolio](https://patrickmorgan.org/).*

--- a/src/content/writing/computational-thinking-is-the-new-literacy.md
+++ b/src/content/writing/computational-thinking-is-the-new-literacy.md
@@ -1,0 +1,44 @@
+---
+title: Computational Thinking is the New Literacy
+description: Why software engineering still matters in an AI world
+publishedDate: 2025-01-12
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/computational-thinking-is-the-new"
+draft: false
+---
+Thinking in patterns. Made with Midjourney.
+
+OpenAI's recent [o3 demo](https://www.youtube.com/live/SKBG1sqdyIU?si=HeS8vHl28bvJ4kJ2) sent shockwaves through the software engineering community. For many programmers, it was their first visceral encounter with AI that was clearly smarter than them. Social media filled with engineers questioning their future, wondering if they would soon be obsolete. But watching the demo, something else struck me: the prompts used contained deep software engineering knowledge that no non-engineer would be able to write.
+
+Take the first seemingly simple [prompt from the demo](https://x.com/itspatmorgan/status/1870536021626208394). In the span of a short paragraph, you needed to understand servers, HTML forms, API requests, file operations, execution environments, and authentication systems. Years of accumulated software knowledge compressed into a few lines of text. If you don't have software training, you wouldn't know to specify these pieces. You might not even realize they're needed.
+
+What we're witnessing isn't the end of software engineering - it's an unbundling of the craft (yes, I know, [I'm on an unbundling kick lately](https://www.unknownarts.co/p/the-great-creative-unbundling)). ***AI is separating the mechanical act of writing code from the deeper art of thinking about systems***. As implementation becomes automated, the human value shifts decisively toward understanding how software should work.
+
+## Hacking it together won't scale
+
+Before my first software development job, I had only worked on small projects - solo or with a couple of other people. It was relatively easy to keep everything in my head, and the stakes were low. It didn’t matter much if an application failed for a bit–it was just a small demo. But then I started working on real business software with many engineers and complex systems. The difference was stark. I discovered that hacking together something I didn't fully understand carried serious risks: breaking critical product features, creating maintenance headaches that wasted other engineers' time, and introducing technical debt that compounded over time.
+
+I'm certain many people will figure out how to get AI to build software without any engineering knowledge. And for simple, personal projects, that might work fine. But running a software business isn't like shipping a static piece of media. It’s dynamic, depending on maintaining and growing systems in the wild. Just like I learned in that transition from demos to professional products, there's a vast difference between getting something to work and creating something that can hold up to ongoing real-world use.
+
+Without deep systems understanding, you'll end up with a fragile patchwork of code that becomes increasingly difficult to manage. Each change becomes a game of prompt roulette, hoping AI will understand enough context to avoid breaking something else. It's like building a house with no understanding of architecture - you might get four walls and a roof, but good luck adding a second story later.
+
+## As machines think like us, we must think like machines
+
+There's an interesting paradox emerging: *the more AI learns to "think" like humans, the more valuable it becomes for humans to understand how machines think*. This suggests we need to rethink what technical literacy means in an AI world. As AI handles implementation details, our focus shifts to higher-level computational thinking - understanding system architecture, recognizing patterns and anti-patterns, knowing what questions to ask, and spotting potential problems before they emerge.
+
+The power of AI tools like o3 is remarkable, but wielding them effectively requires more than just a few simple prompts. The patterns that make software maintainable, the principles that guide good architecture, the wisdom to plan for scale - these insights emerge from experience. They come from thinking deeply about systems, from seeing patterns across projects, and from learning through iteration and failure.
+
+For creative professionals like designers, the old question "should I learn to code?" transforms into "should I learn to think like an engineer?" The syntax becomes less important, but the mental models become more valuable than ever. Understanding how software systems work - their possibilities and constraints - becomes crucial for anyone hoping to create in this new landscape.
+
+## Final thoughts
+
+Those initial reactions to the o3 demo reflected a natural anxiety about change. But they missed a crucial point: *as AI grows more capable at implementation, computational thinking becomes more valuable, not less*. It's evolving from a specialized skill into a fundamental literacy for creating in a world where understanding systems matters more than ever.
+
+The future belongs to those who can think most clearly about how software should work.
+
+Until next time,
+
+Patrick
+
+> *Interested in working together? Check out [my portfolio](https://patrickmorgan.org/).*

--- a/src/content/writing/default-it-or-design-it.md
+++ b/src/content/writing/default-it-or-design-it.md
@@ -1,0 +1,94 @@
+---
+title: Default It or Design It
+description: How I learned to stop sweating every UI detail and ship faster
+publishedDate: 2025-05-25
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/default-it-or-design-it-968"
+draft: false
+---
+Made by me with Midjourney.
+
+I wasted too much time early in my design career sweating the wrong details. Now I ask one question before every UI decision:
+
+**"Default it, or design it?"**
+
+This simple heuristic has saved me countless hours and arguments, especially in startup environments where resources are limited and speed matters.
+
+Every design project requires you to make hundreds of decisions. Some are big like the overall layout. Others are small like the hover state of a button. Facing too many choices can lead to analysis paralysis, making it hard to move forward.
+
+## Why this matters
+
+Problems arise when designers spend too much time on lower-value minutia at the expense of big, strategic decisions: projects stall, deadlines slip, and teams get frustrated.
+
+I've been guilty of this more times than I'd like to admit.
+
+Looking back, I used to get lost trying to solve details that weren't immediately relevant. Like, I'd polish edge cases before the core flow was even solid. I thought I was being thorough but really, I was just misallocating energy.
+
+Now I try to spot where the real leverage is. Not every moment in the product deserves the same attention. Some things just need to work. Others need to shine.
+
+## The two paths
+
+When you **default it**, you're leaning on existing solutions: design systems, platform conventions, or vendor tools. You're not ignoring the problem, you're delegating the decision to something (or someone) that's already solved it well enough.
+
+When you **design it**, you're choosing to spend the time because you believe that decision has the potential to differentiate. You're investing creative energy where it can make a meaningful impact.
+
+Both paths are valid. The power comes from choosing intentionally.
+
+## The "Default It" approach
+
+The "Default It" approach is most valuable when you’re getting hung up on a micro-level detail while working on a macro-level project.
+
+It's not that the detail is unimportant, but it's not the intent of that work. By defaulting micro-level decisions to existing resources, you can expedite macro-level projects.
+
+In my experience, many product managers lean toward this approach. "Defaulting it" helps move projects along faster by reducing scope. But if we default every decision, we're likely to miss opportunities to innovate.
+
+## The "Design It" approach
+
+The "Design It" approach is most valuable when you need headspace to work in-depth on critical choices that shape outcomes in significant ways.
+
+You can make time to "design it" with micro or macro-level work, but each requires your full attention. It can be difficult to toggle between these different points of view, so I find it helpful to scope projects intentionally to focus on one at a time.
+
+Designers naturally gravitate toward this approach. It's where creativity and innovation shine. However, trying to design every small detail can slow projects to a crawl and lead to blown budgets.
+
+## Finding the right balance
+
+Finding the right balance means negotiating which decisions to default and which to design so your team can focus attention in the right places at the right times.
+
+Product managers might push for "defaulting it" to save time and stay on schedule, while designers might advocate for "designing it" to explore creative solutions. This healthy tension can lead to finding the sweet spot for product development.
+
+For example, on one product I worked on, we needed to visualize large graph databases. Building a vector-based visualization library from scratch would have given us flexibility, but it wasn't going to move the needle for our customer experience. We decided to “default” that data viz solution to a third-party vendor whose entire focus was on building that technology. This freed our team to focus on *applying* those tools to solve our customers' problems more quickly and effectively.
+
+## How design systems fit In
+
+As projects grow, certain decisions come up repeatedly. This is where design systems become valuable.
+
+A design system is essentially your collection of team approved defaults.
+
+While in the early days of a product you might default mostly to external industry standards, over time you'll encapsulate more of your own decision-making into custom defaults specific to your service.
+
+By storing your "defaulted" decisions in a central repository, you reduce the overhead for making solid baseline design choices. This list evolves to reflect updated defaults as new projects demand new solutions, freeing up time to focus on unique challenges.
+
+## Final thoughts
+
+"Default it or design it" helps me triage.
+
+It helps my team align.
+
+And it helps us ship.
+
+By intentionally choosing when to default and when to design, I save time, focus on what's critical, and direct my creative energy to the most pressing problems.
+
+Some moments in a product just need to work. Others need to shine.
+
+“Default it or design it” helps me know the difference.
+
+Until next time,
+
+Patrick
+
+***Find this valuable?*** Share it with someone who’d appreciate it.
+
+**Want more like this?** I post insights every weekday on LinkedIn — join me there.
+
+ Get essays every Sunday — 7,000+ already do.

--- a/src/content/writing/how-vibe-coding-improved-my-data-viz-prototypes.md
+++ b/src/content/writing/how-vibe-coding-improved-my-data-viz-prototypes.md
@@ -1,0 +1,115 @@
+---
+title: How Vibe Coding Improved My Data Viz Prototypes
+description: Why I skipped Figma and rebuilt my data viz workflow in code instead
+publishedDate: 2025-05-11
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/the-first-time-vibe-coding-actually"
+draft: false
+---
+Made by me with Midjourney.
+
+Not all vibe coding is useful. But sometimes, it actually helps you do the job better, faster.
+
+Over the past year, I explored a lot of AI tooling during my sabbatical, mostly for personal creative work. I was excited but skeptical about the benefits for my professional product design workflow.
+
+Tools like [Bolt.new](https://bolt.new/), [Lovable](https://lovable.dev/), and [Figma Make](https://www.figma.com/make/) are fun to experiment with, but in a real product environment, especially one like cybersecurity, there’s no way I’m handing off that code and expecting it to reach production.
+
+Then [I joined Sublime Security.](https://www.linkedin.com/posts/itspatmorgan_well-folks-im-back-in-the-startup-game-activity-7308884444239536128--Ek7?utm_source=share&utm_medium=member_desktop&rcm=ACoAAAZtQegB-nJjdIi9kT7naAeZHCCWYKlWcqg) And within a couple weeks, I found a use case for vibe coding that actually made sense. Not as an engineering shortcut, but as a clearer, faster way to communicate design intent inside a constrained, technical system.
+
+## The quick turnaround data viz challenge
+
+Shortly into my new role, our team was preparing for [RSA Conference](https://www.rsaconference.com/) in San Francisco, a major security industry event. We wanted to showcase a dashboard visualizing the value of our new AI security agent.
+
+This posed some immediate challenges:
+
+1. As a new employee, I hadn't yet built out many system resources in Figma
+2. Creating static mockups of data visualizations is always a pain
+3. We use [Apache ECharts](https://echarts.apache.org/en/index.html) for our visualization library, which comes with its own constraints and capabilities
+
+I had a choice: either spend a bunch of time reverse engineering ECharts components into Figma mockups, or find another approach.
+
+## Why static mockups fall short for data viz
+
+If you've designed dashboards before, you know the pain of communicating data visualizations through static design files:
+
+- Interaction details are easier to miss
+- Realistic data distributions are time-consuming to fake
+- Ignoring library constraints leads to design–dev mismatches
+- Engineers still have to translate designs back into library-compatible configurations
+
+All of this is tedious at best.
+
+In my case, since we were already committed to using ECharts, I would effectively be recreating assets that already exist in code, using up my limited time and introducing more opportunity for error.
+
+Ultimately, I decided that wrangling Figma to communicate these charts would’ve cost more time than it was worth.
+
+Screenshot of my workstation. ChatGPT on left, Echarts dev environment on right.
+
+## A better approach: Safe environments for vibe prototyping
+
+Instead of fighting these limitations, I decided to work directly with the tools our engineers use.
+
+ECharts has a built-in [playground demo mode](https://echarts.apache.org/examples/en/editor.html?c=area-stack) where you can prototype specific chart types right in the browser. And since it’s a well-known, publicly documented library, major LLMs like those from OpenAI and Anthropic know about its capabilities. This let me set up a simple vibe coding workspace: ChatGPT on one side, ECharts sandbox on the other.
+
+With this setup, I could:
+
+1. Ask ChatGPT about ECharts capabilities and syntax
+2. Describe what I wanted to achieve from a design perspective
+3. Generate code that I could immediately test in the sandbox
+4. Iterate rapidly until the visualization matched my design intent
+5. Share working examples directly with the engineering team using the sandbox's share link
+
+This approach greatly reduced the [design execution gap](https://www.unknownarts.co/p/the-design-execution-gap-8db).
+
+Engineers could see and feel exactly what I wanted, within the constraints of the library they needed to use to achieve the task.
+
+## What made this valuable
+
+The most important outcome was that I communicated the design intent more clearly and quickly by leaning into a tool that was better suited for the job than static mockups.
+
+I don't know how much of the code I generated was actually used by the engineers on my team. But that's not what mattered.
+
+The value came from:
+
+- **Staying within actual technical constraints** rather than designing fantasy interfaces
+- **Exploring possibilities more efficiently** than reading documentation
+- **Prototyping in the actual medium** that would be used in production
+- **Communicating design intent more clearly** through interactive prototypes
+
+Most importantly, this approach respected everyone’s role. I wasn’t trying to be an engineer—I was using code as a tool to express intent, nothing more.
+
+## When vibe coding actually makes sense in production product design environments
+
+This experience helped me crystallize when the current AI vibe coding tools are genuinely valuable for product designers:
+
+1. **When the goal is communication, not production**
+	- Using code to express intent, not commit to implementation details
+2. **When there's a safe sandbox environment**
+	- Places to experiment where nothing mission-critical can break
+3. **When working within well-defined, constrained systems**
+	- Charting libraries, design systems, UI frameworks with clear documentation
+4. **When the traditional design-to-development handoff creates friction**
+	- Highly interactive elements that static mockups can't adequately represent
+5. **When the design execution translation cost is high**
+	- Complex experiences and interactions where misalignment is expensive
+
+## Vibing beyond data visualization
+
+The point of all of this is not to turn myself into a person who pushes code to production (I don’t want that responsibility).
+
+The point is to communicate my intent as clearly as possible to the people responsible for building it, maximizing the chances we build something great, with quality and speed.
+
+Data visualization is a familiar example that nearly every product designer has grappled with at some point. But this workflow will become increasingly important as the non-deterministic and interactive nature of AI data and workflows requires us to use tools that better communicate designs for those fluid experiences.
+
+This project wasn’t a grand statement about the future of product design. It was simply the best option to get the job done well.
+
+Product design exists to help the team create the thing we’re all trying to build together.
+
+And I’ll happily use any tool that improves the odds we get there.
+
+Until next time,
+
+Patrick
+
+> *This article began as a [LinkedIn post](https://www.linkedin.com/posts/itspatmorgan_not-all-vibe-coding-is-useful-for-product-activity-7320124167305994240-BiTZ?utm_source=share&utm_medium=member_desktop&rcm=ACoAAAZtQegB-nJjdIi9kT7naAeZHCCWYKlWcqg). For insights each weekday, [follow me there](https://www.linkedin.com/in/itspatmorgan/).*

--- a/src/content/writing/i-tried-three-ways-to-ship-a-design-system-heres-what-actually-worked.md
+++ b/src/content/writing/i-tried-three-ways-to-ship-a-design-system-heres-what-actually-worked.md
@@ -1,0 +1,87 @@
+---
+title: "I Tried Three Ways to Ship a Design System. Here's What Actually Worked."
+description: Shipping a successful system takes more than aesthetics - it takes a strategic rollout plan.
+publishedDate: 2025-06-01
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/design-systems-fail-because-of-strategy"
+draft: false
+---
+Made by me with Midjourney.
+
+Nobody wants to hear this, but creating and landing a new design system in existing software is an 18-month project. At best.
+
+Most teams don't make it that far.
+
+I know because I've been the designer on three of these projects, working on complex enterprise apps in cybersecurity and dev tools. Each attempt taught me something new, gradually learning why rollout strategy matters more than immediate aesthetic design choices. What started as hard-won lessons became a framework I now use to guide these decisions.
+
+The products looked different, the teams varied, but the pattern was consistent: great designs failed when implementation was an afterthought, while strategic rollouts succeeded regardless of aesthetic ambition.
+
+Here's what those three attempts taught me.
+
+## The "blow it up" strategy (and why it crushed us)
+
+At Tenable, we went big with a clean-slate redesign of the entire security platform. New visual system, modern components, the works. We spent months crafting something that looked incredible in our design files—the kind of work that gets featured on Dribbble and design twitter.
+
+But once we tried to land it in the actual product, the complexity crushed us. We weren't just updating a visual theme; we were rewiring years of logic and layout. Dependencies stacked up like dominoes. Every component touched three others. Every page required six teams to coordinate.
+
+A year later, the project was dead and the product was worse off than when we started. The head of product design was removed. The CPO followed soon after. We'd burned through enormous resources chasing a vision that couldn't survive contact with reality.
+
+The "blow it up" approach feels creatively satisfying in the moment because it gives you a blank canvas. But software isn't built for wholesale change. It's built for iteration. Fighting that fundamental truth is a losing battle.
+
+## The "Ship of Theseus" strategy (and why it stalled)
+
+At Signal Sciences (now a part of Fastly), we tried the opposite approach. Instead of redesigning everything at once, we'd replace components gradually—like the [ancient thought experiment](https://en.wikipedia.org/wiki/Ship_of_Theseus) where Theseus replaces every plank of his ship over time.
+
+This felt smarter. More aligned with how software actually works. We'd swap out discrete elements over time: style tokens first, then form elements, then navigation patterns, etc. Piece by piece, we’d build our way into a completely new system.
+
+It was working... until it wasn't. Progress was slow and it was hard for the team to maintain momentum. We lacked a sense of urgency and slowly came to a standstill. The company got acquired, and the project froze, half-done.
+
+We ended up with the same old ship, just with 50% new parts. Not worse than before, but not the transformation we'd promised either.
+
+## The "land and expand" strategy (and why it worked)
+
+At JupiterOne, I tried a different approach. Instead of redesigning everything or replacing pieces one by one, we picked one major feature as our pilot project.
+
+This gave us a contained space to design holistically while limiting scope and risk. We built our component library (we called it "Juno") alongside the feature refresh. The real-world context informed the design of the components; the design of the components shaped the real-world feature we shipped.
+
+Once we had the core of a working system and a showcase of what it could do, expanding to other parts of the platform became easier. Other teams could see the value, they had concrete examples to work with, and the organizational support built naturally.
+
+Eighteen months later, the system was live across the platform. Not because we forced it everywhere at once, but because we gave it room to prove itself first and then gradually expand to fit the needs of every product surface.
+
+## Why implementation strategy beats aesthetics
+
+Here's the uncomfortable truth: your beautiful design mockups don't matter if you can't land them in the product.
+
+I've seen teams spend months perfecting component libraries that never get implemented. I've watched gorgeous redesigns die in development hell. I've been part of projects where the design quality was exceptional but the rollout strategy was nonexistent.
+
+The difference in a successful project isn't just having better designers or more skilled developers (although that helps, of course). It's about understanding that replacing a system isn't a visual exercise—it's an architectural one. In most cases, you're not just changing how things look; you're changing how they're built, maintained, and evolved.
+
+That's why implementation strategy is just as crucial as design quality - you need both to succeed. An aesthetically bland system that actually ships beats a perfect system that never sees production. Even if it doesn’t satisfy your immediate urge for novelty, that well-architected UI system will give you the runway to dial in the visual aesthetics over time to the level of fidelity you’re seeking.
+
+## What this means for your next system
+
+If you're starting a design system overhaul, resist the urge to redesign everything.
+
+Instead:
+
+- **Pick your landing zone carefully.** Choose a feature that's important but not mission-critical. Complex enough to test your system and visible enough to build support, but contained enough to manage risk.
+- **Design in context, not isolation.** Build your components alongside real feature work. Let the constraints of actual implementation inform your decisions.
+- **Plan for expansion from day one.** Your pilot isn't just a proof of concept, it's the foundation everything else will build on. Make sure what you’re building can support that weight.
+- **Measure adoption, not perfection.** Success isn't having the most beautiful component library. It's having a system that teams actually use to ship better products faster.
+
+Nobody wants to hear that their beautiful designs might fail because of boring implementation decisions.
+
+But in my experience, that's exactly what happens.
+
+The sooner you accept that reality and plan accordingly, the sooner you can ship systems that make the impact you’re hoping for.
+
+Until next time,
+
+Patrick
+
+***Find this valuable?*** Share it with someone who’d appreciate it.
+
+**Want more like this?** I post insights every weekday on LinkedIn — join me there.
+
+ Get essays every Sunday — 7,000+ already do.

--- a/src/content/writing/the-3-ways-i-ve-tried-to-land-a-design-system-into-existing-software.md
+++ b/src/content/writing/the-3-ways-i-ve-tried-to-land-a-design-system-into-existing-software.md
@@ -1,0 +1,159 @@
+---
+title: The 3 Ways I’ve Tried to Land a Design System Into Existing Software
+description: A success, a partial success, and a failure in systems strategy
+publishedDate: 2023-04-10
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/the-3-ways-ive-tried-to-land-a-design"
+draft: false
+---
+> I have not failed. I’ve just found ten thousand ways that won’t work.
+> 
+> [Thomas Edison](https://www.goodreads.com/quotes/8287-i-have-not-failed-i-ve-just-found-10-000-ways-that)
+
+## Intro
+
+I recently had the pleasure of speaking with a team that’s starting on the journey to land a new design system into an enterprise web app. It’s an exciting time, but also an important moment; how they set and communicate their strategy will heavily influence the potential impact of their work.
+
+Today we’ll explore the strategies I’ve tried for establishing design systems in existing software products at three high-growth tech companies.
+
+Each team used a different strategy for executing the new design vision and while none is 100% right or wrong, they all have trade-offs which I’ll dig into so that you can avoid my mistakes.
+
+Now let’s get to it!
+
+---
+
+Source: The Ringer
+
+## The “blow it up” strategy
+
+### What is it?
+
+You know this strategy. It’s the classic “redesign” project.
+
+In some ways it’s the bread and butter of [waterfall-style design](https://business.adobe.com/blog/basics/waterfall) and development: “Old design isn’t working? Let’s come up with a completely new one all at once!” You try to install an entire system via a reimagined product in one fell swoop.
+
+You get to “flip the switch” to a new experience which can feel awesome but you take on a big burden and a lot of risk in pursuit of that wow factor.
+
+### What do I think about it?
+
+I’ll be upfront: I think this is a bad idea for software. It’s just a bad match for the medium.
+
+***Design*** is very good at big, wholesale change. ***Software*** is very bad at it.
+
+From a design standpoint “blowing it up” is comfortable because it gives a level of perceived creative freedom that people like when making something new. There’s also real merit in being able to step back and design holistically so that you can get the big picture you need to inform how system elements should work in harmony.
+
+From an implementation perspective “blowing it up” is a nightmare. It’s very complex and introduces many dependencies which ramp up the risk. Not only are you trying to design and architect a new experience from scratch, but you’re also trying to ensure that it matches the existing functionality of the old version. That’s a lot of moving pieces.
+
+The experience you’re trying to replace was likely built iteratively over time. Even with the benefit of seeing its current state, the process of re-architecting every feature is lengthy and error-prone. The scope is enormous, which makes this strategy unappealing in all but the most drastic of circumstances.
+
+Due to its high complexity and extended time frame, it’s also possible this strategy gets terminated part way through. This not only makes the whole endeavor feel like a colossal waste of time but can actually leave the new experience worse than the original. A bad outcome for everyone involved.
+
+### How did it manifest in my career?
+
+In my experience, this often manifests when a change occurs in product leadership. People tend to exaggerate the flaws of the software they inherit because it’s not something they personally made. It’s like the exact opposite of the “ [Ikea Effect](https://thedecisionlab.com/biases/ikea-effect) ”; It doesn’t reflect the new leader’s decision-making so the knee-jerk reaction is to blow it up and “do it their way”.
+
+This is the strategy that my team took at [Tenable](https://www.tenable.com/). We did some very cool design work but ultimately failed to deliver on the vision. The experience we designed was [Dribbble](https://dribbble.com/) \-worthy but neither pragmatic nor feasible given our real-world constraints. The project got mostly scrapped after a year of hard work and the experience we shipped was, in my opinion, worse than the original. At best it was a far cry from the “visionary” design we set out to achieve. Also in the process of this slow breakdown, the head of product design got removed from his position and then the chief product officer followed suit.
+
+### Verdict
+
+A clear failure. Would not recommend it. 👎
+
+---
+
+Source: Wikimedia Commons
+
+## The “Ship of Theseus” strategy
+
+### What is it?
+
+The [“Ship of Theseus”](https://www.betterbydesign.cc/i/112989459/the-ship-of-theseus) strategy is the yang to the “blow it up” yin. For context, here’s the first line of the [Wikipedia entry](https://en.wikipedia.org/wiki/Ship_of_Theseus):
+
+> *The **Ship of Theseus** is a thought experiment about whether an object that has had all of its components replaced remains fundamentally the same object.*
+
+In the case of the namesake (the Greek legend Theseus), the story goes that over time he replaced every piece of his ship with a new version. So, after swapping out every board, sail, and so on for a new one, the question was: is it the same ship?
+
+A team following the “Ship of Theseus” strategy would not attempt a wholesale redesign but instead attempt consistent, specific replacements over time. Their goal is to morph the existing experience into something entirely new by swapping all the component pieces for a new version.
+
+### What do I think about it?
+
+It’s a safer strategy than blowing it up but it’s also tough, just for different reasons. It’s more aligned with best practices for iterative software delivery, but due to how incremental it is it’s harder to use it to set up significant design breakthroughs.
+
+Perhaps the biggest issue is that the level of effort for this strategy depends a lot on how systematized your design already is. Good luck trying to swap every instance of a low-level component if you don’t already have a somewhat centralized way to do so. Just like “blowing it up” it’ll be very error-prone and take an eternity.
+
+Another potential issue arises when the new design vision represents a significant aesthetic departure from what exists. In that case, you have two options:
+
+1. You accept that your new elements may feel out of place in the platform for a while until you can get a critical mass of design updated.
+2. You have to dial back your desired aesthetic changes so that they fit better within the bounds of the existing product.
+
+Neither option feels that satisfying for the team despite the technical improvements you might achieve. You’re like “Great, we updated all our buttons to be on the system!”… but overall the product feels basically the same as before which in this context feels like a letdown.
+
+Ultimately this strategy can lead the team to feel like they’re walking in quicksand making little visible progress for their effort. So even though it feels safer at the start, it’s easier for motivation to wane over time and for this kind of project to also get abandoned part way through.
+
+### How did it manifest in my career?
+
+This is the strategy my team took at [Signal Sciences](https://www.signalsciences.com/).
+
+It was mostly successful, but the implementation took long enough to reach a critical mass that it eventually stalled. This was then amplified by the company being acquired by [Fastly](https://www.fastly.com/), stopping progress in its tracks.
+
+Thankfully, by going this route the partially delivered design vision didn’t leave the experience any worse than it was before progress stopped. The design just ended up in a weird place where it was partly on the old system and partly on the new one. It was clearly still the same old ship just with maybe 50% new pieces.
+
+### Verdict
+
+A partial success. Would recommend it if the circumstances are right. 🥲
+
+---
+
+Source: Kevin Indig
+
+## The “land & expand” strategy
+
+### What is it?
+
+“ [Land and expand](https://www.betterbydesign.cc/i/104024275/land-and-expand) ” is a phrase I borrowed from SaaS sales. It describes a customer acquisition and sales growth process in which the first goal is to land a customer on a small deal. Get them in the door. Then as that customer uses your product, you build trust with them by consistently adding more value, expanding your position over time.
+
+With design systems, “landing” a system looks like a very scoped-down version of the “blow it up” strategy. You pick a specific, representative portion of your applications(s) to redesign. This landing spot serves as the initial testing ground and pilot program for your nascent system. Ideally, it is just big enough to represent the majority of the components and patterns that you need to get going.
+
+Then once you’ve done your contained “blow up” and landed the system, “expanding” looks more like the “Ship of Theseus” strategy in that it’s a gradual drive to adopt and refine system elements across all corners of the platform.
+
+### What do I think about it?
+
+I like it! For a number of reasons! 🥳
+
+- It gives designers a big enough scope of work upfront to think holistically while also limiting that scope to one landing point, reducing complexity, dependencies, and risk.
+- The landing point serves as a de facto testing ground for the system. No matter how well-defined a component looks in isolation, it isn’t until you put it in context that you know for sure if it’s delivering.
+- You get both a system starter kit and a visible chunk of new feature UI that represents it, helping you feel the momentum and build organizational support for expanding the system.
+- It allows most of your customer-facing feature design workflows to continue business as usual while you establish system foundations.
+
+### How did it manifest in my career?
+
+This is the strategy I adopted when I joined [JupiterOne](https://jupiterone.com/) in 2021. We started with a pilot project and gradually drove adoption across the platform over the course of roughly 18 months.
+
+#### Landing
+
+At JupiterOne we picked our integrations feature as our system landing point. We thought it was a good candidate for two reasons:
+
+1. It was already in need of work due to new constraints from the company’s growth.
+2. It was an important feature but not the highest profile. So it had sufficient complexity to test the system but not a ton of organizational pressure to deliver anything too mind-blowing.
+
+We stood up the first version of our component library (which we named “Juno”) in tandem with starting work on the feature refresh. The context of the feature development informed the design of the components and the new composition of the components in turn informed the refresh of the feature. Meanwhile, the other 95% of JupiterOne continued to serve our customers in its existing form.
+
+#### Expanding
+
+As the feature and system rounded into shape we brought a second team onboard to begin leveraging Juno components in another part of the platform with the agreement that they would help us test and refine.
+
+This was the first of many expansion points.
+
+Over time, some sections adopted Juno in a more incremental “Ship of Theseus” style, gradually pulling in targeted updates while other sections required something closer to a “blow it up” approach. But in both cases, since the core system elements had already been established, the process of re-architecting was substantially more approachable.
+
+### Verdict
+
+Feels like the sweet spot. Would recommend it! 😇
+
+---
+
+## In sum
+
+- Don’t “blow it up” with software products unless you truly have no alternative.
+- Try to enable “Ship of Theseus” style enhancements, just don’t expect that approach to be the best for establishing *new* systems.
+- Aim to “land” your system with a well-scoped pilot project and then gradually “expand” it over time to the rest of your platform.

--- a/src/content/writing/the-design-execution-gap-1.md
+++ b/src/content/writing/the-design-execution-gap-1.md
@@ -1,0 +1,63 @@
+---
+title: The design execution gap 1
+description: "Why it's hard to stick the landing with design execution and what we might do about it."
+publishedDate: 2022-05-13
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/the-design-execution-gap"
+draft: false
+---
+Here’s a catch-22:
+
+Developers don’t want to own the UI design because they’d rather focus on programming but designers can’t own the design implementation because it’s too tightly coupled to complex front-end logic.
+
+It’s no wonder a lot of companies can’t execute their design vision when the people who want to own the design execution can’t, and the people who do own it, would rather not.
+
+We’re stuck in what I call the “design execution gap”. A place where, despite everyone’s best intent, it’s hard to stick the landing in the last 10% of design execution.
+
+So, where’s the gap coming from? And how might we address it?
+
+### The lessening design gap
+
+The gap used to live more on the design side.
+
+Design tooling simply couldn’t deliver a close approximation of web UI. Web designers were working with inherited tools meant to create static images for print and so every design was just a picture that developers had to interpret and build from scratch based on their eyes alone. It was impossible to work in a design “reality” that even came close to reflecting the reality of the code.
+
+In 2014 when I started working at American Express we solved this problem by embedding UI developers into the product design team to enable us to prototype our designs in code. We’d then hand off that front-end prototype to the official dev team to integrate it into our broader production tech stack. This was my role on that team, actually. Compared to handing off static screens in Illustrator or InDesign this was a far better approach to capturing the team’s true design intent and lessening the execution gap.
+
+But UI design tools have come a long way since that time. They’ve not only gotten generally better, but they’ve focused specifically on designing for the web. First it was integrating Sketch for UI design and testing the waters of some rudimentary re-usable elements. Then we added on a basic interaction layer with things like the Sketch + InVision combo (RIP InVision ☠️). Then finally we started putting the pieces together with tools like today’s dominant player, Figma.
+
+Since adopting Figma I’ve been able to deliver designs that are *much* closer to the reality of the UI we intend to deliver. It’s still not perfect, but between my efforts to align design structure with code structure and Figma’s inspect functionality the developers on my team are now able to get a much more descriptive picture of the UI they’re meant to build.
+
+### The lingering dev gap
+
+The bulk of the gap now is on the development side.
+
+Compared with my Figma handoffs, there’s no good analog to help designers dig into the front-end code to ensure the design is being captured as intended. The front-end of the web has gotten so much more complex and abstract over the last ten years that it’s less accessible for non-developers to contribute to the implementation of the design. The layers of content, style and interactivity are so tightly bound to other logic that it’s at least impractical, if not impossible, for someone to safely contribute without routinely working in the codebase.
+
+Even a designer who is okay with opening the web inspector is stuck. Sure, I can inspect the elements, but since the CSS classes are often generated and scrambled these days, just looking at the markup tells me little about how the interface is composed. It also makes it difficult to work through minor tweaks exclusively in the browser because many of the styles of like-elements are no longer technically shared via the cascade.
+
+This is a problem for the last 10% of design execution. If we were working together in person it would be somewhat less of an issue because I could just sit next to my dev partner to pair on dialing in the details. But in the context of a remote, distributed team it tends to feel like a burden to continually request more and more fine tuning over Slack messages, Zoom invites and Github comments. So I either end up feeling like a pain in the ass or I let a few minor details slide. Not a great situation either way.
+
+So it’s my opinion that we need to find a way to re-expose the stylistic portion of the front-end to the people who both deeply care about it and have the skills to fine tune it. But how?
+
+### A product isn’t the solution... yet
+
+Perhaps your first instinct is to make another product to bridge this gap.
+
+It’s not a bad idea, but I don’t think it’s our first step.
+
+For *websites* (vs. *apps*) we do now have tools like Webflow which give designers more direct control over styling in a visual format that’s more accessible to them. This is a meaningful evolution, it just doesn’t meet my complex, web app use case yet.
+
+At least for the apps that I work on the front-end architecture is sufficiently complex and unique on a company by company basis that I think it would be a challenge to design a product that’s both generic enough to cover all the variation and specific enough to add deep value to my existing workflow (not to mention warrant the expense on my team’s budget).
+
+I’ve tried a number of tools over the years that have attempted to smooth out this middle ground between design and development but have never stuck with them. Why? Because sitting in the middle is awkward. It meant that the tools didn’t fully meet the needs of either designers or developers. They were just kinda okay, and “kinda okay” isn’t enough to merit the overhead of adding one more tool into the telephone game that is communicating and capturing design intent.
+
+### The first step
+
+My instinct is that our first step is not to try solve this with a product, but rather with a cultural and architectural shift on the front-end to begin intentionally crafting a way to make the stylistic portion of the web more approachable for designers. Then, if we’re able to expose that portion of our apps in a standardized way that would in turn facilitate the ability for a product to come in and elevate that basic interface to another level of polished approachability.
+
+To conclude, I want to pose a challenge to both designers and developers to help us move in this direction together:
+
+- As a designer, how might I level up my technical skill to share more ownership of the last 10% of design execution?
+- As a developer, how might I architect a more approachable and inclusive way to craft and maintain application styling?

--- a/src/content/writing/the-end-of-design-certainty.md
+++ b/src/content/writing/the-end-of-design-certainty.md
@@ -1,0 +1,88 @@
+---
+title: The End of Design Certainty
+description: Why AI forces us to embrace emergence instead of clinging to control and understanding
+publishedDate: 2025-02-16
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/the-end-of-design-certainty"
+draft: false
+---
+Anthropic CEO Dario Amodei's recent [podcast with Lex Fridman](https://youtu.be/ugvHCXCOmm4?si=LlUHalCGGHfJLZc7&t=1405) caught my attention with an observation that keeps replaying in my mind. Even as his team works to understand and interpret AI models, he acknowledged a surprising truth:
+
+> *There's no reason why \[AI models\] should be designed for us to understand them, right? They're designed to operate, they're designed to work. Just like the human brain or human biochemistry. They're not designed for a human to open up the hatch, look inside and understand them.*
+
+This statement gave me pause. It challenges something deeply ingrained from the last generation of software design: the idea that *we must fully understand how something works in order to consider it a valid solution*. For years, we’ve doubled down on the belief that ‘data-driven’ design can eliminate uncertainty. The idea is that to make something effective, we first have to deconstruct it, grasp every nuance, and then carefully engineer it into existence.
+
+But there's an irony here: as we've become more obsessed with data-driven certainty, we've invented systems that operate beyond our ability to fully analyze or predict. AI models demonstrate that sometimes the most powerful solutions emerge from patterns we can observe but not fully explain.
+
+AI flips the script. It wasn’t designed for human comprehension—it was designed to work. Understanding, if it comes at all, is often after the fact, something we piece together after we see that the system works. And that realization has forced me to rethink my assumptions about design and invention for this new era.
+
+## Rethinking "solutions in search of problems"
+
+Traditional design wisdom views "solutions in search of problems" as a criticism. It runs counter to everything we're taught about being problem-focused and user-centered. But as Anthropic's head of product design [Joel Lewenstein](https://www.linkedin.com/in/joel-lewenstein/) observed in a recent [Dive Club podcast](https://www.dive.club/deep-dives/joel-lewenstein) with [Michael Riddering](https://www.linkedin.com/in/michaelriddering/): " *I've come to see solutions in search of a problem as not a dirty word at all... as long as you just lean into it and state your assumptions, saying 'look, there's the germ of something here and we're going to explore it.*'"
+
+This isn't about abandoning user-centered design—it's about recognizing that with AI, **understanding often emerges through exploration**. The technology's capabilities are so novel that even those working on the frontier don't know what's possible until they see it.
+
+This shift isn't limited to Anthropic, it's happening across leading AI companies. Inspired by a recent conversation with [Perplexity](https://www.perplexity.ai/) 's head of design [Henry Modisett](https://www.linkedin.com/in/henrymodisett/), [Linear CEO Karri Saarinen commented](https://x.com/karrisaarinen/status/1889734737042002393), " *At Perplexity they start projects by exploring LLM capabilities with very simple prototypes, even with just a command-line implementation. Only once there’s proof that the idea can work consistently, and that they can bend it to do what they want, do they start designing the experience. Normally, you start with design to explore possibilities, and the tech follows. But in this domain, or this new era of software, LLM/AI is the tool for exploration, and design comes after.*"
+
+## Invention comes before understanding
+
+Historically, software design has followed a structured, step-by-step approach—one where every phase is carefully planned to produce a predictable outcome.
+
+1. Understand the problem deeply.
+2. Define a precise solution.
+3. Craft an experience that is intentional and predictable.
+4. Ship a finished product that behaves exactly as expected.
+
+But this isn't how many of the most transformative inventions have come about. If you look at breakthroughs across history, the process is always messy and often *reversed*:
+
+1. Have an intent—an idea of what you're trying to achieve.
+2. Experiment, iterate, and push forward without much clarity.
+3. Uncover an unexpected breakthrough—it works, but not how you thought.
+4. You study the breakthrough, refine it, and later figure out why it works.
+
+This pattern of discovery before understanding runs deep. Alexander Fleming didn’t intend to [discover penicillin](https://www.prayoga.org.in/post/serendipity-and-the-discovery-of-penicillin) —he noticed something unexpected in his experiment and followed the thread. The [steam engine](https://study.com/learn/lesson/steam-engine-history-impact.html) was a product of tinkering; Newcomen and Watt refined working models decades before scientists understood the laws of thermodynamics that made them possible. Early [radio pioneers](https://en.wikipedia.org/wiki/History_of_radio) transmitted signals across great distances without fully understanding the physics of electromagnetic waves. And the use of [anesthesia in surgery](https://www.umhs-sk.org/blog/medical-milestones-discovery-anesthesia-timeline) revolutionized medicine long before scientists figured out its precise mechanism of action.
+
+## AI amplifies this historical pattern
+
+AI doesn’t just follow this pattern—it speeds it up.
+
+Traditional software is **deterministic**; AI is **probabilistic**. It doesn’t follow rigid rules—it generates outputs based on patterns and likelihoods we can observe but not fully predict. The technology itself resists complete upfront understanding.
+
+The challenge is that many designers, engineers, and product teams are still trying to apply legacy design methodologies to a technology that simply doesn't work that way. AI doesn't respect our craving for certainty. It doesn't wait for us to fully understand it before showing results. And the more we try to force it into rigid, explainable, deterministic workflows, the more we suffocate its potential.
+
+## Why design struggles to let go—but why it should
+
+This has forced me to confront my own biases. I've spent a decade designing software, and the instinct to make things fully understood before they exist is deeply ingrained. It's particularly rooted in the culture of UX design—this idea that we can't build effectively unless we first have a full grasp of what we're making.
+
+AI challenges this instinct and asks us to revise our beliefs. It requires us to lean into the ambiguity, to design before we fully understand, and to shape the raw materials of generative outputs as useful options emerge. As [Lewenstein notes](https://youtu.be/GgP9LEAY1PA?si=FttIvp2_iHAhpjsh&t=1612), " *You can talk about AI and you can write about AI, but there's something just so powerful about seeing a working prototype and feeling the dynamic, stochastic nature of it... seeing a website get rendered in real time, iterating on it and seeing it change in front of you—it's just magical.*" Understanding comes through doing, through making something tangible that we can respond to and refine.
+
+Confronting this tension reminds me of the Daoist concept of [Wu Wei](https://www.merriam-webster.com/dictionary/wu%20wei), often translated as "effortless action" or "without force." It's the idea that instead of rigidly trying to control every element of a process, we should move with the natural flow of things—guiding and shaping, rather than imposing. Wu Wei isn’t passivity; it’s about working with forces rather than against them. In AI design, this means crafting interactions where users guide and shape outcomes, rather than micromanaging every detail. It's like how a surfer harnesses a wave’s energy rather than trying to control the ocean.
+
+## Design must guide, not control.
+
+So what does it look like to design *without force*? Instead of suppressing the unknown, we embrace it as part of the process.
+
+- **We** **create affordances, not strict controls**: building interfaces that guide behavior rather than dictate it. Instead of trying to expose every parameter, we need interfaces that let users navigate AI while embracing its variability.
+- **We** **prioritize steerability over explainability**: giving users meaningful, intuitive ways to shape AI’s behavior without needing to understand its internals. The goal isn't to make the black box transparent, but to make it controllable at the right level of abstraction.
+- **We** **embrace emergence**: designing systems that adapt and evolve, rather than ones that are locked into rigid, pre-defined behaviors. This means creating spaces where unexpected capabilities can surface and be refined through use.
+
+This doesn't mean that understanding is unimportant. But it does mean we should be wary of *overprioritizing* upfront understanding at the cost of progress. AI is teaching us that function can—and often must—precede full comprehension. And as designers, builders, and creative thinkers, we need to get more comfortable working in that space.
+
+If this makes you uncomfortable–good. It means you're seeing the shift. But if it excites you–well, my friend, you're right where you need to be.
+
+*What might become possible if you embrace emergence instead of clinging to control?*
+
+## Embracing the unknown
+
+This shift is much bigger than a throwaway line on a podcast. It's a reframe for **how we approach design and invention in this new age.** For decades, the software business has trained us to believe that predictability, explainability, and control are the highest ideals. But many of the most powerful things in the world—our brains, ecosystems, markets, and now AI models—don't operate that way.
+
+If you’re designing with AI, start experimenting before you demand clarity. Try tinkering with the raw materials first, then layering on design afterward—like Perplexity does. Embrace the unknown as a creative tool.
+
+As we build in this new era, we need to ask ourselves: what happens when we stop forcing things to fit our desire for immediate understanding? What becomes possible when we embrace discovery as a design principle? And how do we shape these new, emergent systems in ways that are powerful, safe, and genuinely creative?
+
+We may not fully understand AI yet. But if history tells us anything, that might be exactly where we need to be.
+
+Until next time,
+
+Patrick

--- a/src/content/writing/the-rise-of-software-as-a-workforce.md
+++ b/src/content/writing/the-rise-of-software-as-a-workforce.md
@@ -1,0 +1,58 @@
+---
+title: The Rise of Software as a Workforce
+description: "From SaaS to SaaW: The Dawn of AI Teammates"
+publishedDate: 2024-11-06
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/the-rise-of-software-as-a-workforce"
+draft: false
+---
+For my entire career, I've built software to help people work better. Every feature, every workflow, every interface was designed to be a more effective tool in human hands.
+
+But something profound is happening: software is evolving ***from a tool we use into a workforce we manage***.
+
+This isn't just another iteration of **SaaS (Software as a Service)**. It's the emergence of something new: **SaaW (Software as a Workforce)**. And it's about to change everything about how we build and interact with technology.
+
+The signs are everywhere, if you know where to look. While companies trim thousands of management roles today, they're simultaneously investing heavily in AI capabilities. Here's the irony: the workforce that remains will increasingly become managers themselves – not of people, but of AI teams that create, analyze, and iterate on our behalf.
+
+## Software isn't just making us better—it's working alongside us
+
+The SaaS revolution expanded software's impact by giving us access to continuously improving tools in the cloud. But at its core, SaaS was still about making us better at our jobs. We automated tasks and enhanced collaboration, but remained firmly in the driver's seat.
+
+I've noticed a shift in my work that feels significant: ***I'm no longer just creating better tools – I'm building and onboarding an AI team***.
+
+I'm crafting prototypes of specialized AI teammates for multiple roles: a creative thought-partner to explore new ideas, a writing editor to refine my rough drafts, a graphic designer to handle newsletter visuals. Each one requires the kind of upfront investment you'd expect when bringing on a new team member – conveying context, establishing guidelines, defining workflows, and aligning them with my project's goals and style.
+
+## This changes who gets access to specialized support
+
+Throughout history, influential people have relied on teams of specialists to multiply their impact. Executives had analysts and assistants, performers had producers and promoters, writers had editors and researchers. But building a support staff was a luxury reserved for the wealthy or well-funded.
+
+Something powerful happens when you start thinking about AI as a workforce rather than a tool. Suddenly, support that was previously out of reach for independent creators becomes accessible.
+
+I'm experiencing this firsthand. Instead of working alone, I now have:
+
+- An AI editor who helps refine and strengthen my ideas
+- An AI designer who transforms my concepts into graphics
+- An AI developer who turns my specs into working code
+
+No, they're not perfect replacements for human experts – but they're capable enough to change the game for someone like me. And soon enough, they'll change the game for us all.
+
+## Your relationship with the work fundamentally shifts
+
+Leading a team, whether of humans or AIs, transforms your role. Instead of doing everything yourself, you become an orchestrator of work. This isn't just about automation – it's about changing where you spend your energy. Like any good manager, my job is increasingly about providing clear context upfront and then applying my expertise to refine and polish the output.
+
+Managing this new workforce demands new skills. I'm learning to write better briefs, developing new quality control instincts, and most importantly, finding ways to preserve my creative vision while embracing the possibilities of AI collaboration.
+
+## We're at the very beginning of this shift
+
+I'll be honest: this shift challenges my identity as a craftsman. My pride has always come from the ability to express my ideas via hands-on creation, my gradual personal mastery.
+
+But the future demands I evolve - from a craftsman into a conductor, from a tool user into a team leader. So I'm leaning in, learning to preserve what matters while embracing new ways of creating.
+
+The shift from SaaS to SaaW is just beginning. What feels cutting-edge today will seem quaint tomorrow. By engaging thoughtfully now, we can help steer this evolution.
+
+Let's enrich human creativity rather than replacing it.
+
+Until next time,
+
+Patrick

--- a/src/content/writing/why-i-went-video-first-with-my-design-portfolio-and-how-you-can-too.md
+++ b/src/content/writing/why-i-went-video-first-with-my-design-portfolio-and-how-you-can-too.md
@@ -1,0 +1,141 @@
+---
+title: Why I Went Video-First With My Design Portfolio — And How You Can, Too
+description: A practical guide to how I restructured my portfolio around video presentations.
+publishedDate: 2025-06-08
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/why-i-went-video-first"
+draft: false
+---
+A design portfolio is like a first date.
+
+You can have the looks, but you won't know if there's chemistry until you talk — which is why I went video-first when I started applying to jobs again earlier this year.
+
+Most teams don't just want to see your work. They want to know what it *feels like* to work with you. Video makes that visible, fast. When someone lands on [my portfolio](https://patrickmorgan.org/), they can immediately hear how I talk through problems, see how I communicate design intent, and get a feel for how I show up to work without having to book time with me.
+
+In a world of remote work, async collaboration, and overloaded calendars, that just feels like the honest move for me and for anyone evaluating me.
+
+But I didn't just drop a video on my homepage and call it a day. I rethought how I created the content of my portfolio website starting with the presentations I'm expected to give — then built everything else around that.
+
+I’m not the only one thinking about the potential impact of video portfolios. Designer and [Inflight](https://www.inflight.co/) founder, [Michael Riddering](https://www.linkedin.com/in/michaelriddering/), shared his thoughts on my approach in a [recent edition of his show ‘Dive Club’ on Youtube](https://youtu.be/DqDtO4dAt3o?si=Q5QpfXCewlhBzNsS&t=507). We’re in the early days, but it definitely feels like this format is on the rise.
+
+Here’s how I approached it, step-by-step — and the results.
+
+> 1. **View the site** → [www.patrickmorgan.org](http://patrickmorgan.org/)
+> 2. **View the slide deck** → [Figma Slides Portfolio 2025](https://www.figma.com/slides/uiCrSbG8SwsOJGcJyh5iYg/Portfolio---Slides-2025?node-id=0-1&t=GaPA2RfD61l9HPOF-1)
+> 3. **View a sample project** → [Making a Complex Query Language Approachable](https://patrickmorgan.org/p/pd-query-builder)
+
+---
+
+## Working within my existing visual system
+
+Before diving into the specifics, I want to call out that this wasn't a full brand or website redesign. I'd already designed and shipped an earlier version of my portfolio with **[Framer](https://www.framer.com/)** last year, and I'd spent time refining a personal visual language through my work on Unknown Arts — establishing type, color, and other styles that I liked.
+
+That meant I could focus this effort on upgrading the content of my core projects and communication strategy.
+
+This separation helped me focus and freed up a lot of headspace. I wasn't getting distracted by visual or UI design rabbit holes. I was focused on the clarity of the storytelling.
+
+A few of my core brand elements for Unknown Arts.
+
+## Starting with the presentation
+
+Instead of jumping straight into updating my website, I began with the portfolio presentation I knew I'd have to give in interviews. I wanted to create a clear, compelling narrative for a few representative projects — each chosen to highlight different facets of my design skillset.
+
+I used **[Figma Slides](https://www.figma.com/slides/)** to build the presentation, keeping the process lean and in the same environment where all my assets already lived.
+
+I also created a dedicated Figma file to support this process — a central place to gather existing work samples and create new visuals specifically for storytelling. This became my **portfolio asset library** that I could pull from as I shaped each presentation.
+
+50+ screens to drive storytelling assets for one short case study.
+
+## Refining the story by speaking it out loud
+
+As I practiced the presentations, I found myself naturally iterating. I'd hear when the story didn't land or when I was rambling. And I’d feel when my points lacked visual support.
+
+This speaking-first approach solved a problem I'd struggled with before when creating case studies directly as web pages: I never felt like I could strike the right balance of detail, visual aids, and storytelling. But when I had to speak my story out loud, I naturally found the right level of detail and pacing. ***The constraint forced clarity.***
+
+It kicked off an iterative loop:
+
+- I'd speak the story out loud
+- Identify gaps in the visuals or narrative
+- Jump into my Figma asset file to either pull an existing image or build something new
+- Update the story and repeat
+
+Sometimes I needed to swap a quick screenshot. Other times I needed to design new graphics or build small prototypes. The storytelling shaped the visuals, and the visuals sharpened the story.
+
+Each project went through this process. Over time, I compiled a **[master slide deck](https://www.figma.com/slides/uiCrSbG8SwsOJGcJyh5iYg/Portfolio---Slides-2025?node-id=0-1&t=Du8u89DwbaGILUMd-1)** with all my material — 87 slides across four projects, a career overview, and my work on Unknown Arts. I didn’t intend to present it all at once, but it gave me a central library I could draw from depending on the audience.
+
+Main slide deck with all presentations centralized.
+
+## Recording with purpose
+
+Once the presentations were tight, I recorded myself delivering each one using **[Screen Studio](https://screen.studio/)**. This tool let me pan and zoom on the fly, directing the viewer's attention almost like giving a live talk.
+
+I did multiple takes for each video — not because I wanted perfection, but because those reps helped me dial in the rhythm and clarity. The result was a set of videos that felt polished but natural, and true to how I work.
+
+I uploaded the recordings to **YouTube** as [unlisted videos](https://support.google.com/youtube/answer/157177?sjid=1116539110523473019-NC#unlisted&zippy=%2Cunlisted-videos) so they'd be easy to [embed in Framer](https://www.framer.com/help/articles/how-to-add-video/) but not publicly searchable. These became the centerpiece of each project page.
+
+One project open in Screen Studio. Notice the simple effects timeline.
+
+## Retrofitting content into the site
+
+Because I'd already shaped the story and built the assets, updating the site itself was straightforward.
+
+This is one of those classic web design lessons: *knowing what the content is makes designing the UI a lot more approachable*. I wasn't guessing what to say or filling placeholders; I had the structure, narrative, and visuals dialed in. Updating the site became a matter of slotting a few new pieces into place.
+
+For each project page, I created a consistent structure with **three ways to engage**:
+
+1. **The video** — front and center for a complete walkthrough
+2. **A short text summary** — highlighting core points from the presentation
+3. **The slide deck** — embedded from Figma for quick visual reference
+
+The goal was simple: progressive disclosure with a lightweight touch. Just enough structure for people to engage on their terms.
+
+High level structure of this project page.
+
+## Adding interactive cues
+
+To hint at video presence on the landing page without a major overhaul, I updated my project overview component to reveal short video snippets on hover.
+
+For each project, I exported a few-second, muted, square video clip from the presentation and used it to replace the static project feature image on hover.
+
+This small interaction helped signal there was more available than the typical portfolio site.
+
+Updating my project feature component to support the video hover interaction
+
+---
+
+## Why video makes sense now
+
+Three forces converged to make this approach possible and, in my opinion, necessary:
+
+1. **The tools have made it feasible** — Recording with [Screen Studio](https://screen.studio/), hosting on YouTube, and embedding in [Framer](https://www.framer.com/) turned what used to be a laborious video production project into an afternoon's work.
+2. **Design work demands it** — Modern software design isn’t static. Interaction, flow, and animation are central to what we do and static images struggle to tell the full story.
+3. **Remote work makes it inevitable** — Most of my day-to-day collaboration already happens via async content. I'm constantly sharing Slack posts with design assets, writing Notion docs, and using Loom videos to explain thinking. These videos just reflect how I communicate professionally with a bit more polish.
+
+## The early advantage
+
+We're still early in this trend. I'm not even sure it's a first-mover advantage yet… we might just be ahead of the curve.
+
+But I feel confident about this video-first approach because it benefits both job applicants and hiring teams. *Why jump through hoops scheduling multiple calls to gather information that can be provided upfront?*
+
+As these tools become familiar and expectations shift, I believe video-first portfolios will become standard. But for now, most people still think in terms of traditional resumes, static case studies, and live presentations. There's room to stand out by being more upfront, comprehensive, and authentic than anyone expects.
+
+## Final thoughts
+
+This whole approach is about making the first impression more real, more human, and more useful for both sides.
+
+Video doesn't replace real conversations, but it does make them more productive. Instead of starting from zero, we begin with shared context. Instead of spending early calls figuring out basic compatibility, we can dive deeper, faster.
+
+Top-notch execution is the baseline in today's job market. What sets you apart is how you communicate, how you collaborate, and how you show up with a team.
+
+The setup is simple. The payoff is real.
+
+If you can record a [Loom](https://www.loom.com/), you can make a video-first portfolio.
+
+And whether it leads to a job or not, the more you practice telling your story, the better it gets.
+
+Until next time,
+
+Patrick
+
+PS. *Yes, I wrote 1,500 words to tell you to use video. The irony’s not lost on me. Let’s just pretend I narrated it for today.* 😇

--- a/src/content/writing/why-you-should-curate-not-create-a-design-system.md
+++ b/src/content/writing/why-you-should-curate-not-create-a-design-system.md
@@ -1,0 +1,82 @@
+---
+title: "Why You Should *Curate*, Not Create, a Design System"
+description: How strategic curation and targeted customization can elevate your design practice
+publishedDate: 2023-11-12
+categories:
+  - Newsletter
+canonicalUrl: "https://www.unknownarts.co/p/why-you-should-curate-not-create"
+draft: false
+---
+In software design, it’s tempting to build every component from the ground up.
+
+Industry peer pressure can make you think that creating a bespoke system is the hallmark of innovation and technical prowess. But, in practice, this approach often leads to unnecessary complexity and inefficiency.
+
+I prefer another strategy: **curating a system** – selectively assembling the best existing elements with your own custom creations.
+
+The strength of a software platform lies not in the uniqueness of its components but in how effectively they come together to deliver a product that solves customer problems.
+
+In this article, I want to introduce the idea of strategic curation and highlight a few top-of-mind benefits and concerns that come along with it.
+
+## The case for strategic curation
+
+You don’t have to look far outside the realm of software to find instructive examples of strategically curated business systems.
+
+The physical supply chains of industry giants like Apple and Tesla display a skillful balance of off-the-shelf components, custom-manufactured parts, and in-house innovations. Apple and Tesla customers don’t care whether or not every nut and bolt used to assemble the iPhone or Model 3 was custom built for the project; they care that those chosen pieces combine to create a category leading experience.
+
+As a more specific example, consider Apple’s displays. While Apple's specifications for display panels are high, the fundamental OLED or LCD technology is often sourced from companies like Samsung and LG. Could Apple invent their own display tech? Sure. But by strategically curating from existing, proven elements, it allows the company to direct its creative efforts towards areas that make a bigger impact, like their new, proprietary chipsets. This strategy amplifies, not hinders, their groundbreaking designs.
+
+Strategic curation is about making conscious decisions on where to **innovate** and where to **integrate** (or, as I recently said, [where to design and where to default](https://www.betterbydesign.cc/p/default-it-or-design-it)). When working in this mode, you reserve customization for areas that offer significant competitive differentiation. This means identifying and focusing on elements that augment the unique value of your product. Creating bespoke designs for standard elements like a text input or button likely won’t move the differentiation needle. So, in my experience, it’s been better to integrate worthy existing solutions at this level to allow my teams to innovate where it counts.
+
+Now, let’s explore a couple of benefits and common concerns.
+
+## Benefits
+
+### Improving cost and time efficiency
+
+Building every part of a system from scratch is a herculean effort; it's committing to extensive research, development, testing, and ongoing maintenance. This process consumes valuable resources that could be better used in more strategic areas by most companies.
+
+Curation, in contrast, leverages the wealth of publicly available, well-crafted design elements, dramatically reducing development time and cost. It also enhances agility, allowing for quicker adaptation to market changes and technological advancements. In the startup world where I’ve worked for most of my career, time is of the essence. You might not need to be first to market, but delivering quality solutions quickly is a big advantage.
+
+### Leveraging the experts
+
+Opting for curated elements from reputable sources also brings the advantage of proven quality and expertise.
+
+The startup design teams I’ve worked on have been resource strapped; only a couple of designers to cover the needs of the entire company. We needed designers leaning into their strengths, not struggling with their weaknesses. So outsourcing specific design decisions helped us to operate more effectively and deliver more value to our customers.
+
+One area I outsource regularly is iconography. I’m not great at iconography nor do I aspire to become great at it. So for me, it’s made sense to integrate external icon sources into my work in order to leverage the expertise of real iconography pros.
+
+Another example is data visualization. Designing and building data viz from scratch is challenging, time-consuming, and requires a specific skill set on both sides of the design and engineering aisle. While I have experience in this area, using external libraries made by dedicated experts helps me achieve quality design faster while juggling my other responsibilities.
+
+### Getting ongoing support
+
+When you build complex, bespoke, in-house designs, you put yourself at risk for supporting them over the long haul. Inevitably, whoever designed and built that custom solution will move on to another job and your team will get stuck trying to figure out how to maintain it with little support.
+
+Alternatively, external libraries (whether open source or purchased) foster communities that provide invaluable resources for problem-solving, sharing best practices, and driving continuous innovation. Using them lets you leverage this shared knowledge in your quest to build your software platform and avoid getting stuck.
+
+## Common concerns
+
+### Maintaining brand identity
+
+Designers often fear they’ll lose their product’s unique brand identity in the process of curation. This is an understandable but unfounded fear.
+
+Much of a software product’s unique feel is captured in primitive level theme settings which can be applied to any higher order UI component: typography, color, spacing, effects, etc… So, provided your team sets strong foundations for theming via these systematic primitives, the components you choose shouldn’t limit your ability to create a unique visual identity.
+
+### Balancing familiarity with novelty
+
+As I’ve written about before, [finding the balance between familiarity and novelty is crucial for designing hit products](https://www.betterbydesign.cc/p/special-edition-the-most-advanced). Using a base of familiar components doesn’t reject novelty; it sets the stage for intentionally designing standout novel moments.
+
+iOS design is a good reference for finding this balance in software. iOS comes with a robust set of familiar components that developers can use to create experiences that align with Apple’s standards. Strategically curating Apple’s components allows for a beneficial consistency in the user experience of iOS apps while leaving room for you to add unique elements that differentiate your product. The same thinking applies to web apps, except the core library isn’t clearly provided by a single company.
+
+### Managing resource constraints
+
+When you choose to integrate an external resource into your software, you also accept that resource’s constraints. Once you start building upon that tech, it’s easy to get [“locked in”](https://www.betterbydesign.cc/p/the-subtle-art-of-keeping-your-options) to it, making it hard and expensive to replace with another technology. This means you should pick your libraries wisely, because you’ll likely be with them for the long haul and they set the stage for what’s feasible in your designs.
+
+UI quality can suffer if you change course and start overriding every aspect of an external resource so either lean into that resource’s strengths or cut bait and go a different direction. The only thing worse than a messy bespoke solution is a messy bespoke customization built on top of an external library you don’t control.
+
+## Final thoughts
+
+In conclusion, the art of curation in design systems is more than just a practical approach; it's a strategic imperative in today's rapidly evolving digital landscape. It encourages designers to think critically about each component, to recognize the value of existing solutions, and to direct their creative efforts towards areas where they can make a real difference. This approach doesn’t merely lead to better design; it results in smarter, more sustainable, and impactful products that resonate with users and endure in an ever-changing marketplace.
+
+Until next time,
+
+Patrick

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -148,25 +148,25 @@ const impactStatements: Record<string, string> = {
       Writing
     </h2>
     <div class="group mb-10 overflow-hidden rounded-lg border border-border">
-      <div class="overflow-hidden">
+      <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="block overflow-hidden">
         <img
           src="/images/unknown-arts/banner.webp"
           alt="Unknown Arts newsletter"
           class="aspect-video w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
         />
-      </div>
+      </a>
       <div class="p-5 sm:p-6">
         <div class="mb-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-8">
           <p class="text-sm leading-relaxed text-muted-foreground sm:flex-1">
-            <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Unknown Arts</a> is my weekly newsletter for creative builders exploring AI design and the creative frontier.
+            <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Unknown Arts</a> is my newsletter for creative builders in the age of AI.
           </p>
           <div class="flex gap-6 sm:shrink-0">
             <div>
-              <p class="text-lg font-semibold tracking-tight">7,400+</p>
+              <p class="text-lg font-semibold tracking-tight">7,500+</p>
               <p class="font-mono text-xs text-muted-foreground">Subscribers</p>
             </div>
             <div>
-              <p class="text-lg font-semibold tracking-tight">190+</p>
+              <p class="text-lg font-semibold tracking-tight">200+</p>
               <p class="font-mono text-xs text-muted-foreground">Articles</p>
             </div>
             <div>


### PR DESCRIPTION
## Summary

- Syncs 15 new articles from Obsidian vault
- Wraps newsletter banner image in a link to unknownarts.co
- Updates newsletter section description and stats (7,500+ subscribers, 200+ articles)
- Fixes sync script bug where empty `tags` field wrote a bare `tags:` YAML key, causing Astro schema validation errors

Closes #31

## Test plan

- [ ] 15 new articles appear on /writing
- [ ] Newsletter banner image links to unknownarts.co
- [ ] `pnpm sync-writing` runs with no schema errors on articles with empty tags
- [ ] No build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)