### PR TITLE
Animate color mode toggle with View Transitions API

### DIFF
--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -11,9 +11,20 @@ export function ThemeToggle() {
 
   function toggleTheme() {
     const next = theme === "dark" ? "light" : "dark";
-    setTheme(next);
-    document.documentElement.classList.toggle("dark", next === "dark");
-    localStorage.setItem("theme", next);
+
+    const apply = () => {
+      setTheme(next);
+      document.documentElement.classList.toggle("dark", next === "dark");
+      localStorage.setItem("theme", next);
+    };
+
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (!reduced && "startViewTransition" in document) {
+      (document as Document & { startViewTransition: (cb: () => void) => void })
+        .startViewTransition(apply);
+    } else {
+      apply();
+    }
   }
 
   return (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -98,6 +98,31 @@
   }
 }
 
+/* Color mode cross-fade via View Transitions API */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 250ms;
+  animation-timing-function: ease-in-out;
+}
+
+::view-transition-old(root) {
+  animation-name: fade-out;
+}
+
+::view-transition-new(root) {
+  animation-name: fade-in;
+}
+
+@keyframes fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 /* Prose styles for markdown content */
 .prose {
   @apply text-foreground leading-relaxed;


### PR DESCRIPTION
## Summary

- Uses `document.startViewTransition()` to cross-fade the entire page when switching between light and dark mode
- 250ms ease-in-out via `::view-transition-old/new` CSS pseudo-elements
- Falls back to instant toggle for `prefers-reduced-motion` and unsupported browsers (Safari <18, older Chrome)

Part of #34.

## Test plan
- [ ] Toggle dark/light: smooth cross-fade, no flash
- [ ] Toggle rapidly: each transition completes cleanly
- [ ] With `prefers-reduced-motion` enabled: instant switch, no animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)