### PR TITLE
Redesign resume page

### DIFF
--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -1,10 +1,4 @@
-export interface BulletPoint {
-  title: string;
-  description: string;
-}
-
 export interface Role {
-  section: string;
   company: string;
   logo?: string;
   role: string;
@@ -12,52 +6,23 @@ export interface Role {
   descriptions: string[];
 }
 
-export const bulletPoints: BulletPoint[] = [
-  {
-    title: "Philosophy Meets Political Communications",
-    description:
-      "Studied political science at Davidson College focusing on philosophy, communications, and media impact.",
-  },
-  {
-    title: "Strategic Foundation",
-    description:
-      "Started my career as a strategist at Leo Burnett, crafting brand narratives for major clients.",
-  },
-  {
-    title: "Transition to Tech",
-    description:
-      "Shifted my focus to technology and code, bridging strategic thinking with technical expertise.",
-  },
-  {
-    title: "Technical Product Design Specialist",
-    description:
-      "Began as a design engineer at American Express. Grew to lead product design at high-growth enterprise startups. Designed complex software products like cybersecurity platforms.",
-  },
-  {
-    title: "Empowering Creators in AI",
-    description:
-      "Created Unknown Arts, a newsletter for creative builders in the age of AI, growing to 7,500+ subscribers. Also organized events fostering community connection and growth.",
-  },
-];
-
 export const roles: Role[] = [
-  // Product Design
   {
-    section: "Product Design",
     company: "Sublime Security",
     logo: "/images/logos/career-sublime.svg",
     role: "Staff Product Designer",
-    dateRange: "Current",
+    dateRange: "2025–Now",
     descriptions: [
-      "Joined as the first product designer in March 2025. Now a senior staff IC.",
+      "Designed a multi-agent system pairing an analyst agent with a detection engineering agent — automating threat triage and continuously generating new detection rules in Sublime's custom DSL.",
+      "Shipped security features for high-stakes scenarios: Email Bomb protection, vendor impersonation and compromise, and automated threat detection.",
+      "Built an internal prototyping platform with Claude Code — sole designer and engineer. Now used daily by the full design team.",
     ],
   },
   {
-    section: "Product Design",
     company: "JupiterOne",
     logo: "/images/logos/career-jupiterone.svg",
-    role: "Principal Product Designer",
-    dateRange: "2022\u20132023",
+    role: "Lead Product Designer",
+    dateRange: "2022–2023",
     descriptions: [
       "Designed a query interface that reduced new user time-to-value from 21 days to 1 day.",
       "Drove creation and adoption of a new design system across enterprise security platform.",
@@ -65,63 +30,41 @@ export const roles: Role[] = [
     ],
   },
   {
-    section: "Product Design",
     company: "Signal Sciences",
     logo: "/images/logos/career-sigsci.svg",
     role: "Senior Product Designer",
-    dateRange: "2019\u20132021",
+    dateRange: "2019–2021",
     descriptions: [
       "Designed features for enterprise firewall rules management, rate limiting, and bot defense.",
       "Facilitated strong design, dev, and PM collaboration via workshops, systems diagramming, storyboarding, prototyping, and presentations.",
     ],
   },
   {
-    section: "Product Design",
     company: "Tenable",
     logo: "/images/logos/career-tenable.svg",
     role: "Product Designer",
-    dateRange: "2017\u20132018",
+    dateRange: "2017–2018",
     descriptions: [
-      "Designed enterprise SaaS features to improve Tenable\u2019s cyber risk platform: dashboard creation & management, data visualization templates, & team credential management.",
+      "Designed enterprise SaaS features to improve Tenable's cyber risk platform: dashboard creation & management, data visualization templates, & team credential management.",
     ],
   },
   {
-    section: "Product Design",
     company: "American Express",
     logo: "/images/logos/career-amex.svg",
     role: "Design Engineer",
-    dateRange: "2013\u20132016",
+    dateRange: "2013–2016",
     descriptions: [
       "Built UI for a multi-brand platform used by Amex, Walmart, and Target.",
-      "Led prototyping in code to design flexible and robust responsive web UX",
+      "Led prototyping in code to design flexible and robust responsive web UX.",
     ],
   },
-  // Writing & Community
   {
-    section: "Writing & Community",
-    company: "Unknown Arts",
-    logo: "/images/logos/career-unknownarts.svg",
-    role: "Founder & Writer",
-    dateRange: "2022\u2013Present",
-    descriptions: [
-      "Created a newsletter growing to 7,500+ subscribers and ~40% open rate.",
-      "Featured in top industry publications, reaching a global audience across 128 countries.",
-      "Organized events fostering community connection and growth.",
-    ],
-  },
-  // Brand
-  {
-    section: "Brand",
     company: "Leo Burnett",
     logo: "/images/logos/career-leoburnett.svg",
     role: "Brand Strategist",
-    dateRange: "2012\u20132013",
+    dateRange: "2012–2013",
     descriptions: [
       "Developed brand strategies using consumer research and cultural insights, creating high impact communications for clients like Allstate, MillerCoors, and Sprint.",
     ],
   },
 ];
-
-/** Get unique sections in order */
-export const sections = [...new Set(roles.map((r) => r.section))];
-

--- a/src/data/site-config.ts
+++ b/src/data/site-config.ts
@@ -1,11 +1,11 @@
 export const siteConfig = {
   name: "Patrick Morgan",
-  title: "Patrick Morgan — Product Designer",
+  title: "Patrick Morgan — Software Designer",
   description:
-    "Staff product designer building AI-powered tools at Sublime Security and writing Unknown Arts — a newsletter for creative builders in the age of AI.",
+    "Software designer building AI-powered tools at Sublime Security and writing Unknown Arts — a newsletter for creative builders in the age of AI.",
   url: "https://itspatmorgan.github.io",
   nav: [
-    { label: "Resume", href: "/resume" },
+    { label: "Resumé", href: "/resume" },
     { label: "Writing", href: "/writing" },
   ],
   social: {
@@ -13,6 +13,6 @@ export const siteConfig = {
     linkedin: "https://www.linkedin.com/in/itspatmorgan",
     github: "https://github.com/itspatmorgan",
     newsletter: "https://www.unknownarts.co",
-    email: "itspatmorgan@gmail.com",
+    email: "pm@itspatmorgan.com",
   },
 } as const;

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,78 +1,174 @@
 ---
 import PageLayout from "@/layouts/PageLayout.astro";
-import LogoCarousel from "@/components/LogoCarousel.astro";
-import { bulletPoints, roles, sections } from "@/data/experience";
+import { roles } from "@/data/experience";
+
+const arcNodes = ["Strategist", "Developer", "Designer", "Writer", "Builder"];
 ---
 
-<PageLayout title="Resume — Patrick Morgan" description="12+ years merging design, technology, and storytelling to create human-centered experiences.">
-  {/* Hero */}
-  <section class="mx-auto max-w-3xl px-6 pt-12 pb-8 sm:pt-24 sm:pb-12">
-    <h1 class="mb-4 text-4xl font-medium tracking-tight sm:text-5xl">Resume</h1>
-    <p class="max-w-lg text-lg text-muted-foreground">
-      12+ years merging design, technology, and storytelling to create human-centered experiences.
+<PageLayout title="Resumé — Patrick Morgan" description="12+ years merging design, technology, and storytelling to create human-centered experiences.">
+  {/* Hero + Career Arc */}
+  <section class="mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24" data-resume-hero style="opacity: 0">
+    <h1 class="mb-3 text-4xl font-medium tracking-tight sm:text-5xl">Resumé</h1>
+    <p class="mb-8 text-lg text-muted-foreground">12+ years of product design across cybersecurity, enterprise SaaS, and AI.</p>
+    <div class="flex flex-wrap items-center gap-1.5 sm:gap-2">
+      {arcNodes.map((label, i, arr) => (
+        <>
+          <span
+            class="arc-node rounded border px-2 py-0.5 font-mono text-[11px] sm:px-3 sm:py-1 sm:text-xs"
+            class:list={[i === arr.length - 1 ? "arc-node-final" : ""]}
+            style={`animation-delay: ${i * 700}ms`}
+          >
+            {label}
+          </span>
+          {i < arr.length - 1 && (
+            <span class="font-mono text-xs text-muted-foreground/40">→</span>
+          )}
+        </>
+      ))}
+    </div>
+  </section>
+
+  {/* Experience — intro + timeline */}
+  <section class="mx-auto max-w-3xl border-t border-border px-6 pt-12" data-resume-intro style="opacity: 0">
+    <p class="mb-16 text-base leading-relaxed text-foreground/70">
+      My career has never been one note. I've been a strategist, a developer, a designer, and a writer — sometimes all at once. What connects them is a compulsion to make things that are both useful and well-crafted. Right now that means designing AI tools at Sublime Security, writing articles for Unknown Arts, and building my own software with Claude Code.
     </p>
-  </section>
 
-  {/* Career Logos */}
-  <section class="mx-auto max-w-3xl px-6 pb-16">
-    <LogoCarousel />
-  </section>
+    {/* Career label */}
+    <p class="mb-10 font-mono text-xs uppercase tracking-widest text-muted-foreground">Career</p>
 
-  {/* The Bullet Points */}
-  <section class="mx-auto max-w-3xl border-t border-border px-6 py-16">
-    <h2 class="mb-8 font-mono text-xs uppercase tracking-widest text-muted-foreground">
-      The Bullet Points
-    </h2>
-    <div class="flex flex-col gap-5">
-      {bulletPoints.map((bp) => (
-        <div>
-          <h3 class="mb-1 text-sm font-semibold">{bp.title}</h3>
-          <p class="text-sm leading-relaxed text-muted-foreground">{bp.description}</p>
+    {/* Timeline */}
+    <div class="relative">
+      <div class="absolute left-[5px] top-2 bottom-0 w-px bg-border"></div>
+
+      {roles.map((role) => (
+        <div class="relative mb-12 last:mb-0 pl-8" data-timeline-entry style="opacity: 0">
+          <div class="absolute left-0 top-[3px] size-[11px] rounded-full border border-border bg-background"></div>
+
+          <div class="mb-5 font-mono text-xs text-muted-foreground">{role.dateRange}</div>
+
+          {role.logo && (
+            <img src={role.logo} alt={role.company} class="logo-adaptive mb-4 h-5" />
+          )}
+
+          <p class="mb-5 text-base font-semibold leading-snug">{role.role}</p>
+
+          <ul class="flex flex-col gap-5">
+            {role.descriptions.map((desc) => (
+              <li class="text-sm leading-relaxed text-muted-foreground">{desc}</li>
+            ))}
+          </ul>
         </div>
       ))}
     </div>
   </section>
 
-  {/* Career Sections */}
-  {sections.map((section, i) => {
-    const sectionRoles = roles.filter((r) => r.section === section);
-    const isLast = i === sections.length - 1;
-    return (
-      <section class:list={["mx-auto max-w-3xl border-t border-border px-6 py-16", isLast && "pb-24"]}>
-        <h2 class="mb-10 font-mono text-xs uppercase tracking-widest text-muted-foreground">
-          {section}
-        </h2>
-        <div class="flex flex-col gap-10">
-          {sectionRoles.map((role) => (
-            <div class="flex flex-col gap-3 sm:flex-row sm:gap-10">
-              {/* Date range */}
-              <div class="sm:w-24 sm:shrink-0 sm:pt-1">
-                <p class="font-mono text-xs text-muted-foreground">{role.dateRange}</p>
-              </div>
-              {/* Role details */}
-              <div class="flex-1">
-                <div class="mb-4 flex items-center gap-3">
-                  {role.logo && (
-                    <img
-                      src={role.logo}
-                      alt={role.company}
-                      class="logo-adaptive h-5"
-                    />
-                  )}
-                </div>
-                <p class="mb-2 text-sm font-semibold">{role.role}</p>
-                <ul class="flex flex-col gap-2">
-                  {role.descriptions.map((desc) => (
-                    <li class="text-sm leading-relaxed text-muted-foreground">
-                      {desc}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          ))}
+  {/* Unknown Arts */}
+  <section class="mx-auto max-w-3xl px-6 pt-20 pb-16" data-resume-ua style="opacity: 0">
+    <p class="mb-10 font-mono text-xs uppercase tracking-widest text-muted-foreground">Writing</p>
+    <div class="mb-5 font-mono text-xs text-muted-foreground">2022–Now</div>
+    <img src="/images/logos/career-unknownarts.svg" alt="Unknown Arts" class="logo-adaptive mb-4 h-5" />
+    <p class="mb-5 text-base font-semibold leading-snug">Writer</p>
+    <ul class="flex flex-col gap-5">
+      <li class="text-sm leading-relaxed text-muted-foreground">Created a newsletter growing to 7,500+ subscribers and ~40% open rate.</li>
+      <li class="text-sm leading-relaxed text-muted-foreground">Featured in top industry publications, reaching a global audience across 128 countries.</li>
+      <li class="text-sm leading-relaxed text-muted-foreground">Organized events fostering community connection and growth.</li>
+    </ul>
+  </section>
+
+  {/* Skills */}
+  <section class="mx-auto max-w-3xl px-6 pt-6 pb-24" data-resume-skills style="opacity: 0">
+    <p class="mb-10 font-mono text-xs uppercase tracking-widest text-muted-foreground">Skills</p>
+    <div class="flex flex-col gap-5">
+      {[
+        { label: "Design", skills: ["Product design", "Prototyping", "Interaction design", "Systems design", "Design systems", "User research", "Figma", "Framer", "Midjourney"] },
+        { label: "Dev", skills: ["HTML", "CSS", "Javascript", "React", "Tailwind", "ShadCN", "Git", "Github", "Claude Code", "Astro", "PNPM"] },
+        { label: "Domains", skills: ["B2B & Enterprise SaaS", "Cybersecurity", "FinTech"] },
+      ].map(({ label, skills }) => (
+        <div>
+          <p class="mb-2 font-mono text-xs uppercase tracking-widest text-muted-foreground/60">{label}</p>
+          <p class="text-sm leading-relaxed text-foreground/70">{skills.join(" · ")}</p>
         </div>
-      </section>
-    );
-  })}
+      ))}
+    </div>
+  </section>
 </PageLayout>
+
+<style>
+  /* ── Arc node animation ───────────────────────────── */
+  .arc-node {
+    color: var(--muted-foreground);
+    border-color: var(--border);
+    background: transparent;
+    animation: arcFlash 1.1s cubic-bezier(0.4, 0, 0.6, 1) both;
+  }
+
+  .arc-node-final {
+    animation: arcActivate 1.1s cubic-bezier(0.4, 0, 0.6, 1) both;
+  }
+
+  @keyframes arcFlash {
+    0%, 100% {
+      color: var(--muted-foreground);
+      border-color: var(--border);
+      background: transparent;
+    }
+    40%, 60% {
+      color: var(--foreground);
+      border-color: color-mix(in oklch, var(--foreground) 20%, transparent);
+      background: color-mix(in oklch, var(--foreground) 4%, transparent);
+    }
+  }
+
+  @keyframes arcActivate {
+    0% {
+      color: var(--muted-foreground);
+      border-color: var(--border);
+      background: transparent;
+    }
+    100% {
+      color: var(--foreground);
+      border-color: color-mix(in oklch, var(--foreground) 20%, transparent);
+      background: color-mix(in oklch, var(--foreground) 4%, transparent);
+    }
+  }
+</style>
+
+<script>
+  import { animate } from "motion";
+
+  function init() {
+    const hero = document.querySelector<HTMLElement>("[data-resume-hero]");
+    const intro = document.querySelector<HTMLElement>("[data-resume-intro]");
+    const spring = { type: "spring" as const, stiffness: 160, damping: 20, mass: 0.8 };
+
+    if (hero) animate(hero, { opacity: [0, 1], y: [16, 0] }, { ...spring });
+    if (intro) animate(intro, { opacity: [0, 1] }, { duration: 0.4, easing: "ease-out", delay: 0.2 });
+
+    const skills = document.querySelector<HTMLElement>("[data-resume-skills]");
+    const ua = document.querySelector<HTMLElement>("[data-resume-ua]");
+    if (skills) animate(skills, { opacity: [0, 1] }, { duration: 0.4, easing: "ease-out", delay: 0.3 });
+    if (ua) animate(ua, { opacity: [0, 1] }, { duration: 0.4, easing: "ease-out", delay: 0.35 });
+
+    const entries = document.querySelectorAll<HTMLElement>("[data-timeline-entry]");
+    const observer = new IntersectionObserver(
+      (observed) => {
+        observed.forEach(entry => {
+          if (entry.isIntersecting) {
+            animate(
+              entry.target as HTMLElement,
+              { opacity: [0, 1], y: [10, 0] },
+              { type: "spring", stiffness: 140, damping: 18, mass: 0.8 }
+            );
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -40px 0px" }
+    );
+    entries.forEach(el => observer.observe(el));
+  }
+
+  init();
+  document.addEventListener("astro:after-swap", init);
+</script>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -10,7 +10,7 @@ const posts = (await getCollection("writing", ({ data }) => !data.draft))
 
 <PageLayout title="Writing — Patrick Morgan" description="Articles on AI, design, and the creative frontier.">
   {/* Hero */}
-  <section class="mx-auto max-w-3xl px-6 pt-12 pb-8 sm:pt-24 sm:pb-12">
+  <section class="mx-auto max-w-3xl px-6 pt-12 pb-8 sm:pt-24 sm:pb-12" data-writing-hero style="opacity: 0">
     <h1 class="mb-4 text-4xl font-medium tracking-tight sm:text-5xl">Writing</h1>
     <p class="max-w-lg text-lg text-muted-foreground">
       Thoughts on AI, design, and the creative frontier. Subscribe to
@@ -24,7 +24,7 @@ const posts = (await getCollection("writing", ({ data }) => !data.draft))
   </section>
 
   {/* Articles */}
-  <section class="mx-auto max-w-3xl border-t border-border px-6 py-16 pb-24">
+  <section class="mx-auto max-w-3xl border-t border-border px-6 py-16 pb-24" data-writing-list style="opacity: 0">
     <div class="flex flex-col gap-2">
       {posts.map((post) => (
         <ArticleListItem
@@ -38,3 +38,19 @@ const posts = (await getCollection("writing", ({ data }) => !data.draft))
     </div>
   </section>
 </PageLayout>
+
+<script>
+  import { animate } from "motion";
+
+  function init() {
+    const hero = document.querySelector<HTMLElement>("[data-writing-hero]");
+    const list = document.querySelector<HTMLElement>("[data-writing-list]");
+    const spring = { type: "spring" as const, stiffness: 160, damping: 20, mass: 0.8 };
+
+    if (hero) animate(hero, { opacity: [0, 1], y: [16, 0] }, { ...spring });
+    if (list) animate(list, { opacity: [0, 1] }, { duration: 0.4, easing: "ease-out", delay: 0.2 });
+  }
+
+  init();
+  document.addEventListener("astro:after-swap", init);
+</script>


### PR DESCRIPTION
## Summary

- Full redesign of the resume page: credential subheadline, animated career arc diagram, chronological timeline with spine/dot and scroll-triggered entry animations, separate Writing section for Unknown Arts, new Skills section
- Cleans up `experience.ts` (removes unused types and fields)
- Fixes nav label spelling to Resumé
- Adds matching page-level load animation to the Writing index page for consistency

## Test plan

- [ ] Resume page loads and animates correctly (hero spring, timeline scroll-trigger, arc diagram)
- [ ] Arc diagram fits on one line on mobile (or wraps gracefully)
- [ ] Dark mode renders correctly (logos invert, colors hold)
- [ ] Writing page animates on load
- [ ] Nav shows "Resumé" spelling

Closes #38
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)