### PR TITLE
Extend editorial generator patterns and motion controls

### DIFF
--- a/.claude/plans/editorial-pattern-integration.md
+++ b/.claude/plans/editorial-pattern-integration.md
@@ -1,0 +1,33 @@
+# Editorial Pattern Integration
+
+## Context
+
+The editorial art tool now provides deterministic generator foundations that can carry more of the site's visual identity. This pass brings those patterns into the main portfolio experience without turning the site into a motion-heavy showcase.
+
+## Approach
+
+- Reuse the existing `GenerativeCanvas` and generator config types.
+- Add a small decorative React island for theme-aware, ambient pattern surfaces.
+- Integrate patterns into the global footer and the home page Unknown Arts newsletter feature.
+- Keep motion reveal-based and hover/focus replay-based, respecting reduced motion.
+
+## Files to Modify
+
+- `src/lab/editorial-art/GenerativePatternSurface.tsx`: reusable pattern surface island.
+- `src/components/layout/Footer.astro`: global footer pattern treatment.
+- `src/pages/index.astro`: Unknown Arts newsletter feature pattern treatment.
+- `src/styles/global.css`: writing-list accent styling.
+
+## Steps
+
+1. Create the reusable pattern surface with light/dark awareness and parent-triggered replay.
+2. Add a quiet footer pattern behind the existing footer content.
+3. Replace the static newsletter banner image with a stronger animated Unknown Arts pattern hero.
+4. Add a restrained hover strip to writing list items.
+5. Verify with build and browser checks.
+
+## Verification
+
+- Run `pnpm build`.
+- Run `pnpm dev` and inspect home, writing, project, resume, and lab routes in light/dark mode.
+- Confirm reduced-motion users do not receive replay animation.

--- a/src/components/lab/LabPreview.astro
+++ b/src/components/lab/LabPreview.astro
@@ -1,7 +1,7 @@
 ---
 import PixelWaveText from "@/components/PixelWaveText.astro";
 import { GenerativeCanvas } from "@/lab/editorial-art/GenerativeCanvas";
-import { brand } from "@/lab/editorial-art/themes";
+import { brand, revealMotion } from "@/lab/editorial-art/themes";
 
 interface Props {
   preview: string;
@@ -21,7 +21,7 @@ const editorialPreview = {
 <div class="relative aspect-[1200/630] overflow-hidden bg-card texture-bg">
   {preview === "editorial-art" && (
     <div class="absolute inset-0 bg-[#171716]">
-      <GenerativeCanvas config={editorialPreview} bgColor={brand.warmDarkGray} animate client:load />
+      <GenerativeCanvas config={editorialPreview} bgColor={brand.warmDarkGray} motion={revealMotion} client:load />
       <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-[#171716]/95 via-[#171716]/15 to-transparent"></div>
       <div class="pointer-events-none absolute bottom-4 left-4 right-4 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-widest text-[#ede9e3]/70">
         <span>Strange Attractor</span>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,9 +1,37 @@
 ---
 import { siteConfig } from "@/data/site-config";
+import { GenerativePatternSurface } from "@/lab/editorial-art/GenerativePatternSurface";
+
+const footerPattern = {
+  type: "flow-field",
+  seed: 614,
+  density: 170,
+  steps: 80,
+  scale: 420,
+  curl: -22,
+  strokeWidth: 0.9,
+  opacity: 52,
+  color: "copper",
+} as const;
+
+const footerLightPattern = {
+  ...footerPattern,
+  opacity: 42,
+  color: "bronze",
+  strokeWidth: 1.2,
+} as const;
 ---
 
-<footer class="border-t border-border py-16">
-  <div class="mx-auto max-w-3xl px-6">
+<footer class="relative overflow-hidden border-t border-border py-16" data-generative-pattern-trigger>
+  <GenerativePatternSurface
+    name="site-footer"
+    config={footerPattern}
+    lightConfig={footerLightPattern}
+    duration={3200}
+    className="absolute inset-0 opacity-35 mix-blend-multiply [mask-image:linear-gradient(to_bottom,transparent_0%,black_28%,black_100%)] dark:opacity-45 dark:mix-blend-screen"
+    client:visible
+  />
+  <div class="relative z-10 mx-auto max-w-3xl px-6">
     <h2 class="mb-3 text-2xl font-medium tracking-tight">Get in touch!</h2>
     <p class="mb-8 max-w-lg text-sm leading-relaxed text-muted-foreground">
       Always excited to connect with fellow creators and curious minds.

--- a/src/lab/editorial-art/ArtCanvas.tsx
+++ b/src/lab/editorial-art/ArtCanvas.tsx
@@ -10,6 +10,7 @@ import {
   CANVAS_H,
   type Composition,
   type GeneratorConfig,
+  type MotionConfig,
   type TextFont,
 } from './themes';
 
@@ -23,6 +24,8 @@ export interface CanvasProps {
   showText: boolean;
   composition: Composition;
   textFont: TextFont;
+  motion: MotionConfig;
+  motionReplayKey?: number;
 }
 
 // ── Caption text ──────────────────────────────────────────────────────────────
@@ -88,7 +91,7 @@ const titleFonts: Record<TextFont, React.CSSProperties> = {
 // ── Canvas ────────────────────────────────────────────────────────────────────
 
 export const ArtCanvas = forwardRef<HTMLDivElement, CanvasProps>(function ArtCanvas(
-  { title, bgColor, generator, texture, grain, showCaption, showText, composition, textFont },
+  { title, bgColor, generator, texture, grain, showCaption, showText, composition, textFont, motion, motionReplayKey = 0 },
   ref
 ) {
   const isDark = isColorDark(bgColor);
@@ -167,8 +170,10 @@ export const ArtCanvas = forwardRef<HTMLDivElement, CanvasProps>(function ArtCan
 
       {/* Generative layer */}
       <GenerativeCanvas
+        key={motionReplayKey}
         config={generator}
         bgColor={bgColor}
+        motion={motion}
         style={{ position: 'absolute', inset: 0 }}
       />
 

--- a/src/lab/editorial-art/GenerativeCanvas.tsx
+++ b/src/lab/editorial-art/GenerativeCanvas.tsx
@@ -7,12 +7,13 @@ interface Props {
   bgColor: string;
   animate?: boolean;
   duration?: number;
+  transparentBackground?: boolean;
   className?: string;
   style?: CSSProperties;
 }
 
-export function GenerativeCanvas({ config, bgColor, animate, duration, className, style }: Props) {
-  const { canvasRef } = useGenerativeCanvas(config, bgColor, { animate, duration });
+export function GenerativeCanvas({ config, bgColor, animate, duration, transparentBackground, className, style }: Props) {
+  const { canvasRef } = useGenerativeCanvas(config, bgColor, { animate, duration, transparentBackground });
   return (
     <canvas
       ref={canvasRef}

--- a/src/lab/editorial-art/GenerativeCanvas.tsx
+++ b/src/lab/editorial-art/GenerativeCanvas.tsx
@@ -1,19 +1,19 @@
 import type { CSSProperties } from 'react';
-import { type GeneratorConfig } from './themes';
-import { useGenerativeCanvas, type UseGenerativeCanvasOptions } from './useGenerativeCanvas';
+import { type GeneratorConfig, type MotionConfig } from './themes';
+import { useGenerativeCanvas } from './useGenerativeCanvas';
 
 interface Props {
   config: GeneratorConfig;
   bgColor: string;
-  animate?: boolean;
+  motion?: MotionConfig;
   duration?: number;
   transparentBackground?: boolean;
   className?: string;
   style?: CSSProperties;
 }
 
-export function GenerativeCanvas({ config, bgColor, animate, duration, transparentBackground, className, style }: Props) {
-  const { canvasRef } = useGenerativeCanvas(config, bgColor, { animate, duration, transparentBackground });
+export function GenerativeCanvas({ config, bgColor, motion, duration, transparentBackground, className, style }: Props) {
+  const { canvasRef } = useGenerativeCanvas(config, bgColor, { motion, duration, transparentBackground });
   return (
     <canvas
       ref={canvasRef}

--- a/src/lab/editorial-art/GenerativePatternSurface.tsx
+++ b/src/lab/editorial-art/GenerativePatternSurface.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { GenerativeCanvas } from './GenerativeCanvas';
+import { brand, type GeneratorConfig } from './themes';
+
+interface Props {
+  name: string;
+  config: GeneratorConfig;
+  lightConfig?: GeneratorConfig;
+  darkConfig?: GeneratorConfig;
+  className?: string;
+  duration?: number;
+  interactive?: boolean;
+}
+
+function readIsDark(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.documentElement.classList.contains('dark');
+}
+
+function readReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function defaultLightConfig(config: GeneratorConfig): GeneratorConfig {
+  return {
+    ...config,
+    color: config.color === 'copper' ? 'bronze' : config.color,
+    opacity: Math.min(100, Math.max(config.opacity, 82)),
+    ...('strokeWidth' in config ? { strokeWidth: Math.min(2.4, config.strokeWidth * 1.35) } : {}),
+  } as GeneratorConfig;
+}
+
+export function GenerativePatternSurface({
+  name,
+  config,
+  lightConfig,
+  darkConfig,
+  className,
+  duration = 2600,
+  interactive = false,
+}: Props) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [isDark, setIsDark] = useState(readIsDark);
+  const [replayKey, setReplayKey] = useState(0);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => setIsDark(readIsDark()));
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!interactive) return;
+    const root = rootRef.current;
+    const trigger = root?.parentElement?.closest('[data-generative-pattern-trigger]');
+    if (!trigger) return;
+
+    const replay = () => {
+      if (!readReducedMotion()) setReplayKey((key) => key + 1);
+    };
+
+    trigger.addEventListener('mouseenter', replay);
+    trigger.addEventListener('focusin', replay);
+    return () => {
+      trigger.removeEventListener('mouseenter', replay);
+      trigger.removeEventListener('focusin', replay);
+    };
+  }, [interactive]);
+
+  const resolvedConfig = useMemo(() => {
+    if (isDark) return darkConfig ?? config;
+    return lightConfig ?? defaultLightConfig(config);
+  }, [config, darkConfig, isDark, lightConfig]);
+
+  const bgColor = isDark ? brand.warmDarkGray : brand.paper;
+
+  return (
+    <div
+      ref={rootRef}
+      aria-hidden="true"
+      className={className}
+      data-generative-pattern-surface={name}
+      style={{ pointerEvents: 'none' }}
+    >
+      <GenerativeCanvas
+        key={`${name}-${isDark ? 'dark' : 'light'}-${replayKey}`}
+        config={resolvedConfig}
+        bgColor={bgColor}
+        animate
+        duration={duration}
+        transparentBackground
+      />
+    </div>
+  );
+}

--- a/src/lab/editorial-art/GenerativePatternSurface.tsx
+++ b/src/lab/editorial-art/GenerativePatternSurface.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { GenerativeCanvas } from './GenerativeCanvas';
-import { brand, type GeneratorConfig } from './themes';
+import { brand, revealMotion, type GeneratorConfig, type MotionConfig } from './themes';
 
 interface Props {
   name: string;
@@ -10,6 +10,7 @@ interface Props {
   className?: string;
   duration?: number;
   interactive?: boolean;
+  motion?: MotionConfig;
 }
 
 function readIsDark(): boolean {
@@ -39,6 +40,7 @@ export function GenerativePatternSurface({
   className,
   duration = 2600,
   interactive = false,
+  motion = revealMotion,
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [isDark, setIsDark] = useState(readIsDark);
@@ -87,7 +89,7 @@ export function GenerativePatternSurface({
         key={`${name}-${isDark ? 'dark' : 'light'}-${replayKey}`}
         config={resolvedConfig}
         bgColor={bgColor}
-        animate
+        motion={motion}
         duration={duration}
         transparentBackground
       />

--- a/src/lab/editorial-art/LiveEditorialVisual.tsx
+++ b/src/lab/editorial-art/LiveEditorialVisual.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { GenerativeCanvas } from './GenerativeCanvas';
-import { brand, type GeneratorConfig } from './themes';
+import { brand, revealMotion, type GeneratorConfig, type LayerColor } from './themes';
 
 interface LightModeConfig {
-  color: string;
+  color: LayerColor;
   opacity: number;
   strokeWidth?: number;
 }
@@ -57,7 +57,7 @@ export function LiveEditorialVisual({ visual }: Props) {
       aria-hidden="true"
       style={{ position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none' }}
     >
-      <GenerativeCanvas config={generator} bgColor={bgColor} animate />
+      <GenerativeCanvas config={generator} bgColor={bgColor} motion={revealMotion} />
     </div>
   );
 }

--- a/src/lab/editorial-art/generators/attractor.ts
+++ b/src/lab/editorial-art/generators/attractor.ts
@@ -1,4 +1,4 @@
-import { CANVAS_W, CANVAS_H, type StrangeAttractorConfig } from '../themes';
+import { CANVAS_W, CANVAS_H, type StrangeAttractorConfig, type RenderContext } from '../themes';
 import { makeRng } from './noise';
 
 const W = CANVAS_W;
@@ -87,7 +87,7 @@ export function drawAttractor(
   opacity: number,
   w: number,
   h: number,
-  progress = 1,
+  render: RenderContext,
 ): void {
   const { xs, ys, count, minX, maxX, minY, maxY } = data;
   const maxA = (opacity / 100) * 0.92;
@@ -96,7 +96,36 @@ export function drawAttractor(
   const g = parseInt(color.slice(3, 5), 16);
   const b = parseInt(color.slice(5, 7), 16);
 
-  const visibleCount = Math.floor(count * Math.min(progress, 1));
+  const ambient = render.motion.mode === 'ambient';
+
+  if (ambient) {
+    const speed = render.motion.speed / 100;
+    const intensity = Math.pow(render.motion.intensity / 100, 1.05);
+    const time = render.time * (0.00005 + speed * 0.00017);
+    const sampleCount = Math.min(count, Math.floor(70_000 + 110_000 * intensity));
+    const start = Math.floor((time % 1) * count);
+    const pointSize = Math.max(1, Math.round(Math.min(w, h) / CANVAS_H));
+
+    ctx.save();
+    ctx.fillStyle = color;
+    ctx.globalCompositeOperation = 'lighter';
+
+    for (let i = 0; i < sampleCount; i++) {
+      const idx = (start + i) % count;
+      const px = Math.floor(toScreen(xs[idx], minX, maxX, w));
+      const py = Math.floor(toScreen(ys[idx], minY, maxY, h));
+      if (px < 0 || px >= w || py < 0 || py >= h) continue;
+      const local = i / sampleCount;
+      const envelope = Math.sin(local * Math.PI);
+      ctx.globalAlpha = Math.min(0.22, maxA * (0.035 + envelope * (0.08 + 0.14 * intensity)));
+      ctx.fillRect(px, py, pointSize, pointSize);
+    }
+
+    ctx.restore();
+    return;
+  }
+
+  const visibleCount = Math.floor(count * Math.min(render.progress, 1));
 
   // Always use density map so the animation is a smooth accumulation throughout
   const density = new Uint32Array(w * h);

--- a/src/lab/editorial-art/generators/dotGrid.ts
+++ b/src/lab/editorial-art/generators/dotGrid.ts
@@ -77,16 +77,12 @@ export function drawDotGrid(
       : smoothstep((render.progress - distanceDelay * 0.78 - fieldDelay) / 0.22);
     if (revealAlpha <= 0) continue;
 
-    const pulse = ambient
-      ? Math.sin(time + cx * 0.018 + cy * 0.023) * Math.cos(time * 0.7 + cx * 0.007)
+    const wave = ambient
+      ? Math.sin(time + cx * 0.014 + cy * 0.019)
       : 0;
-    const shimmer = ambient
-      ? Math.sin(time * 1.3 + cx * 0.011 - cy * 0.019)
-      : 0;
-    const animatedRadius = Math.max(0.3, r * (1 + pulse * 0.42 * intensity));
-    ctx.globalAlpha = ambient
-      ? Math.max(0.08, Math.min(1, baseAlpha * revealAlpha * (1 + shimmer * 0.9 * intensity)))
-      : baseAlpha * revealAlpha;
+    const animatedRadius = Math.max(0.3, r * (1 + wave * 0.24 * intensity));
+    const alphaScale = ambient ? 0.72 + (wave + 1) * 0.38 * intensity : 1;
+    ctx.globalAlpha = Math.max(0, Math.min(1, baseAlpha * revealAlpha * alphaScale));
     ctx.beginPath();
     ctx.arc(cx * scaleX, cy * scaleY, animatedRadius * Math.min(scaleX, scaleY), 0, Math.PI * 2);
     ctx.fill();

--- a/src/lab/editorial-art/generators/dotGrid.ts
+++ b/src/lab/editorial-art/generators/dotGrid.ts
@@ -1,8 +1,17 @@
-import { CANVAS_W, CANVAS_H, type DotGridConfig } from '../themes';
+import { CANVAS_W, CANVAS_H, type DotGridConfig, type RenderContext } from '../themes';
 import { noise } from './noise';
 
 const W = CANVAS_W;
 const H = CANVAS_H;
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function smoothstep(value: number): number {
+  const t = clamp01(value);
+  return t * t * (3 - 2 * t);
+}
 
 export interface Dot {
   cx: number;
@@ -42,20 +51,44 @@ export function drawDotGrid(
   opacity: number,
   w: number,
   h: number,
-  progress = 1,
+  render: RenderContext,
 ): void {
   const scaleX = w / W;
   const scaleY = h / H;
-  const end = Math.floor(dots.length * progress);
+  const ambient = render.motion.mode === 'ambient';
+  const speed = render.motion.speed / 100;
+  const intensity = Math.pow(render.motion.intensity / 100, 1.08);
+  const time = render.time * (0.00022 + speed * 0.00058);
 
   ctx.save();
-  ctx.globalAlpha = (opacity / 100) * 0.80;
   ctx.fillStyle = color;
+  const baseAlpha = (opacity / 100) * 0.80;
 
-  for (let i = 0; i < end; i++) {
+  for (let i = 0; i < dots.length; i++) {
     const { cx, cy, r } = dots[i];
+    const nx = cx / W;
+    const ny = cy / H;
+    const dx = nx - 0.42;
+    const dy = ny - 0.52;
+    const distanceDelay = Math.sqrt(dx * dx + dy * dy) / 0.72;
+    const fieldDelay = (Math.sin(cx * 0.017 + cy * 0.011) + 1) * 0.055;
+    const revealAlpha = render.progress >= 1
+      ? 1
+      : smoothstep((render.progress - distanceDelay * 0.78 - fieldDelay) / 0.22);
+    if (revealAlpha <= 0) continue;
+
+    const pulse = ambient
+      ? Math.sin(time + cx * 0.018 + cy * 0.023) * Math.cos(time * 0.7 + cx * 0.007)
+      : 0;
+    const shimmer = ambient
+      ? Math.sin(time * 1.3 + cx * 0.011 - cy * 0.019)
+      : 0;
+    const animatedRadius = Math.max(0.3, r * (1 + pulse * 0.42 * intensity));
+    ctx.globalAlpha = ambient
+      ? Math.max(0.08, Math.min(1, baseAlpha * revealAlpha * (1 + shimmer * 0.9 * intensity)))
+      : baseAlpha * revealAlpha;
     ctx.beginPath();
-    ctx.arc(cx * scaleX, cy * scaleY, r * Math.min(scaleX, scaleY), 0, Math.PI * 2);
+    ctx.arc(cx * scaleX, cy * scaleY, animatedRadius * Math.min(scaleX, scaleY), 0, Math.PI * 2);
     ctx.fill();
   }
 

--- a/src/lab/editorial-art/generators/flowField.ts
+++ b/src/lab/editorial-art/generators/flowField.ts
@@ -1,4 +1,4 @@
-import { CANVAS_W, CANVAS_H, type FlowFieldConfig } from '../themes';
+import { CANVAS_W, CANVAS_H, type FlowFieldConfig, type RenderContext } from '../themes';
 import { noise, makeRng } from './noise';
 
 const W = CANVAS_W;
@@ -43,23 +43,53 @@ export function drawFlowField(
   strokeWidth: number,
   w: number,
   h: number,
-  progress = 1,
+  render: RenderContext,
 ): void {
   const scaleX = w / W;
   const scaleY = h / H;
+  const ambient = render.motion.mode === 'ambient';
+  const speed = render.motion.speed / 100;
+  const intensity = Math.pow(render.motion.intensity / 100, 1.05);
+  const time = render.time * (0.00016 + speed * 0.0005);
+  const baseAlpha = (opacity / 100) * 0.65;
 
   ctx.save();
-  ctx.globalAlpha = (opacity / 100) * 0.65;
   ctx.strokeStyle = color;
-  ctx.lineWidth = strokeWidth;
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
 
-  for (const { points } of paths) {
-    const end = Math.max(2, Math.floor(points.length * progress));
+  for (let pathIndex = 0; pathIndex < paths.length; pathIndex++) {
+    const { points } = paths[pathIndex];
+    const end = Math.max(2, Math.floor(points.length * render.progress));
+    const visibleEnd = ambient ? points.length : end;
+
+    if (ambient) {
+      ctx.globalAlpha = baseAlpha * (0.18 + 0.22 * intensity);
+      ctx.lineWidth = strokeWidth * 0.85;
+    } else {
+      ctx.globalAlpha = baseAlpha;
+      ctx.lineWidth = strokeWidth;
+    }
+
     ctx.beginPath();
     ctx.moveTo(points[0][0] * scaleX, points[0][1] * scaleY);
-    for (let i = 1; i < end; i++) {
+    for (let i = 1; i < visibleEnd; i++) {
+      ctx.lineTo(points[i][0] * scaleX, points[i][1] * scaleY);
+    }
+    ctx.stroke();
+
+    if (!ambient || points.length < 6) continue;
+
+    const phase = (time + pathIndex * 0.037) % 1;
+    const head = Math.floor(phase * points.length);
+    const windowSize = Math.max(5, Math.floor(points.length * (0.16 + 0.24 * intensity)));
+    const tail = Math.max(0, head - windowSize);
+
+    ctx.globalAlpha = Math.min(1, baseAlpha * (0.65 + 0.55 * intensity));
+    ctx.lineWidth = strokeWidth * (1.15 + 0.85 * intensity);
+    ctx.beginPath();
+    ctx.moveTo(points[tail][0] * scaleX, points[tail][1] * scaleY);
+    for (let i = tail + 1; i <= head; i++) {
       ctx.lineTo(points[i][0] * scaleX, points[i][1] * scaleY);
     }
     ctx.stroke();

--- a/src/lab/editorial-art/generators/isoline.ts
+++ b/src/lab/editorial-art/generators/isoline.ts
@@ -1,4 +1,4 @@
-import { CANVAS_W, CANVAS_H, type IsolineConfig } from '../themes';
+import { CANVAS_W, CANVAS_H, type IsolineConfig, type RenderContext } from '../themes';
 import { noise } from './noise';
 
 const W = CANVAS_W;
@@ -87,24 +87,40 @@ export function drawIsolines(
   strokeWidth: number,
   w: number,
   h: number,
-  progress = 1,
+  render: RenderContext,
 ): void {
   const scaleX = w / W;
   const scaleY = h / H;
-  const end = Math.max(1, Math.floor(levels.length * progress));
+  const end = Math.max(1, Math.floor(levels.length * render.progress));
+  const ambient = render.motion.mode === 'ambient';
+  const speed = render.motion.speed / 100;
+  const intensity = Math.pow(render.motion.intensity / 100, 1.08);
+  const time = render.time * (0.00012 + speed * 0.00032);
+  const drift = 24 * intensity * Math.min(scaleX, scaleY);
+
+  const point = (x: number, y: number, phase: number): [number, number] => {
+    const sx = x * scaleX;
+    const sy = y * scaleY;
+    if (!ambient || drift <= 0) return [sx, sy];
+    const waveA = Math.sin(time + phase + x * 0.012 + y * 0.006);
+    const waveB = Math.cos(time * 0.85 + phase + x * 0.004 - y * 0.014);
+    return [sx + waveA * drift, sy + waveB * drift];
+  };
 
   ctx.save();
   ctx.globalAlpha = (opacity / 100) * 0.70;
   ctx.strokeStyle = color;
-  ctx.lineWidth = strokeWidth;
+  ctx.lineWidth = ambient ? strokeWidth * (1 + 0.45 * intensity) : strokeWidth;
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
 
   ctx.beginPath();
   for (let i = 0; i < end; i++) {
     for (const [x1, y1, x2, y2] of levels[i]) {
-      ctx.moveTo(x1 * scaleX, y1 * scaleY);
-      ctx.lineTo(x2 * scaleX, y2 * scaleY);
+      const [px1, py1] = point(x1, y1, i * 0.31);
+      const [px2, py2] = point(x2, y2, i * 0.31 + 0.17);
+      ctx.moveTo(px1, py1);
+      ctx.lineTo(px2, py2);
     }
   }
   ctx.stroke();

--- a/src/lab/editorial-art/generators/voronoi.ts
+++ b/src/lab/editorial-art/generators/voronoi.ts
@@ -1,4 +1,4 @@
-import { CANVAS_W, CANVAS_H, type VoronoiConfig } from '../themes';
+import { CANVAS_W, CANVAS_H, type RenderContext, type VoronoiConfig } from '../themes';
 import { makeRng } from './noise';
 
 const W = CANVAS_W;
@@ -108,26 +108,56 @@ export function drawVoronoi(
   strokeWidth: number,
   w: number,
   h: number,
-  progress = 1,
+  render: RenderContext,
 ): void {
   const scaleX = w / W;
   const scaleY = h / H;
-  const end = Math.floor(edges.length * progress);
+  const ambient = render.motion.mode === 'ambient';
+  const speed = render.motion.speed / 100;
+  const intensity = Math.pow(render.motion.intensity / 100, 1.05);
+  const time = render.time * (0.00014 + speed * 0.00046);
+  const end = ambient ? edges.length : Math.floor(edges.length * render.progress);
+  const baseAlpha = (opacity / 100) * 0.75;
+  const baseWidth = strokeWidth * Math.min(scaleX, scaleY);
 
   ctx.save();
-  ctx.globalAlpha = (opacity / 100) * 0.75;
   ctx.strokeStyle = color;
-  ctx.lineWidth = strokeWidth;
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
 
-  ctx.beginPath();
+  if (!ambient) {
+    ctx.globalAlpha = baseAlpha;
+    ctx.lineWidth = baseWidth;
+    ctx.beginPath();
+    for (let i = 0; i < end; i++) {
+      const [x1, y1, x2, y2] = edges[i];
+      ctx.moveTo(x1 * scaleX, y1 * scaleY);
+      ctx.lineTo(x2 * scaleX, y2 * scaleY);
+    }
+    ctx.stroke();
+    ctx.restore();
+    return;
+  }
+
   for (let i = 0; i < end; i++) {
     const [x1, y1, x2, y2] = edges[i];
-    ctx.moveTo(x1 * scaleX, y1 * scaleY);
-    ctx.lineTo(x2 * scaleX, y2 * scaleY);
+    const mx = (x1 + x2) * 0.5;
+    const my = (y1 + y2) * 0.5;
+    const wave = Math.sin(time + mx * 0.012 + my * 0.018 + i * 0.031);
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.hypot(dx, dy) || 1;
+    const offset = wave * 6 * intensity;
+    const ox = (-dy / len) * offset;
+    const oy = (dx / len) * offset;
+
+    ctx.globalAlpha = Math.max(0, Math.min(1, baseAlpha * (0.42 + (wave + 1) * 0.34 * intensity)));
+    ctx.lineWidth = baseWidth * (0.9 + (wave + 1) * 0.28 * intensity);
+    ctx.beginPath();
+    ctx.moveTo((x1 + ox) * scaleX, (y1 + oy) * scaleY);
+    ctx.lineTo((x2 + ox) * scaleX, (y2 + oy) * scaleY);
+    ctx.stroke();
   }
-  ctx.stroke();
 
   ctx.restore();
 }

--- a/src/lab/editorial-art/index.tsx
+++ b/src/lab/editorial-art/index.tsx
@@ -181,10 +181,6 @@ function parseMotion(params: URLSearchParams, fallback: MotionConfig): MotionCon
   };
 }
 
-function supportsAmbientMotion(type: GeneratorType): boolean {
-  return type !== 'voronoi';
-}
-
 function motionWithObviousDefaults(current: MotionConfig, mode: MotionMode): MotionConfig {
   if (mode !== 'ambient') return { ...current, mode };
   return {
@@ -978,11 +974,6 @@ export default function EditorialArtTool() {
                   ))}
                 </div>
               </SettingsRow>
-            )}
-            {state.motion.mode === 'ambient' && !supportsAmbientMotion(generator.type) && (
-              <p className="font-mono text-[10px] text-muted-foreground/60 leading-relaxed">
-                Voronoi stays static in Ambient for this pass. Use Reveal to test its motion.
-              </p>
             )}
               </PanelSection>
 

--- a/src/lab/editorial-art/index.tsx
+++ b/src/lab/editorial-art/index.tsx
@@ -9,11 +9,14 @@ import {
   brandAccent,
   resolveLayerColor,
   isColorDark,
+  staticMotion,
   type ThemeId,
   type LayerColor,
   type Composition,
   type GeneratorConfig,
   type GeneratorType,
+  type MotionConfig,
+  type MotionMode,
   type FlowFieldConfig,
   type DotGridConfig,
   type IsolineConfig,
@@ -37,6 +40,7 @@ interface AppState {
   slugEdited: boolean;
   composition: Composition;
   textFont: TextFont;
+  motion: MotionConfig;
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -73,6 +77,12 @@ const TEXT_FONTS: { value: TextFont; label: string }[] = [
   { value: 'sans',  label: 'Sans'  },
   { value: 'mono',  label: 'Mono'  },
   { value: 'pixel', label: 'Pixel' },
+];
+
+const MOTION_MODES: { value: MotionMode; label: string }[] = [
+  { value: 'static',  label: 'Static'  },
+  { value: 'reveal',  label: 'Reveal'  },
+  { value: 'ambient', label: 'Ambient' },
 ];
 
 const SURFACE_PRESETS = [
@@ -116,6 +126,7 @@ function defaultState(themeId: ThemeId): AppState {
     slugEdited: false,
     composition: t.defaultComposition,
     textFont: 'sans',
+    motion: { ...staticMotion },
   };
 }
 
@@ -150,6 +161,27 @@ function numberParam(params: URLSearchParams, key: string, fallback: number): nu
 
 function colorParam(value: string | null, fallback: LayerColor): LayerColor {
   return COLORS.some((color) => color.value === value) ? value as LayerColor : fallback;
+}
+
+function motionModeParam(value: string | null, fallback: MotionMode): MotionMode {
+  return MOTION_MODES.some((mode) => mode.value === value) ? value as MotionMode : fallback;
+}
+
+function parseMotion(params: URLSearchParams, fallback: MotionConfig): MotionConfig {
+  return {
+    mode: motionModeParam(params.get('motion'), fallback.mode),
+    speed: Math.max(0, Math.min(100, numberParam(params, 'motionSpeed', fallback.speed))),
+    intensity: Math.max(0, Math.min(100, numberParam(params, 'motionIntensity', fallback.intensity))),
+  };
+}
+
+function motionWithObviousDefaults(current: MotionConfig, mode: MotionMode): MotionConfig {
+  if (mode !== 'ambient') return { ...current, mode };
+  return {
+    mode,
+    speed: Math.max(current.speed, 72),
+    intensity: Math.max(current.intensity, 58),
+  };
 }
 
 function parseGenerator(params: URLSearchParams, fallback: GeneratorConfig): GeneratorConfig {
@@ -206,6 +238,7 @@ function parseGenerator(params: URLSearchParams, fallback: GeneratorConfig): Gen
 }
 
 function initialStateFromUrl(): AppState {
+  if (typeof window === 'undefined') return defaultState('ai');
   const params = new URLSearchParams(window.location.search);
   const themeId = themeIdFromParam(params.get('theme'));
   const state = defaultState(themeId);
@@ -222,6 +255,7 @@ function initialStateFromUrl(): AppState {
     } as GeneratorConfig,
     texture: numberParam(params, 'texture', state.texture),
     grain: numberParam(params, 'grain', state.grain),
+    motion: parseMotion(params, state.motion),
   };
 }
 
@@ -231,15 +265,17 @@ function switchGeneratorType(current: GeneratorConfig, toType: GeneratorType): G
   // Safely read scale from configs that have it; fall back to sensible defaults.
   const currentScale = 'scale' in current ? (current as { scale: number }).scale : 300;
   const currentStrokeWidth = 'strokeWidth' in current ? (current as { strokeWidth: number }).strokeWidth : 0.7;
+  const visibleOpacity = Math.max(current.opacity, 92);
+  const visibleStrokeWidth = Math.max(currentStrokeWidth, 1.1);
 
   if (toType === 'dot-grid') {
     return {
       type: 'dot-grid',
       seed:    current.seed,
-      spacing: 20,
-      scale:   Math.max(100, Math.min(600, currentScale)),
-      dotSize: 75,
-      opacity: current.opacity,
+      spacing: 18,
+      scale:   Math.max(100, Math.min(420, currentScale)),
+      dotSize: 92,
+      opacity: visibleOpacity,
       color:   current.color,
     } satisfies DotGridConfig;
   }
@@ -247,10 +283,10 @@ function switchGeneratorType(current: GeneratorConfig, toType: GeneratorType): G
     return {
       type:        'isoline',
       seed:        current.seed,
-      levels:      10,
-      scale:       Math.max(100, Math.min(600, currentScale)),
-      strokeWidth: currentStrokeWidth,
-      opacity:     current.opacity,
+      levels:      14,
+      scale:       Math.max(100, Math.min(420, currentScale)),
+      strokeWidth: visibleStrokeWidth,
+      opacity:     visibleOpacity,
       color:       current.color,
     } satisfies IsolineConfig;
   }
@@ -258,10 +294,10 @@ function switchGeneratorType(current: GeneratorConfig, toType: GeneratorType): G
     return {
       type:        'voronoi',
       seed:        current.seed,
-      count:       80,
-      jitter:      75,
-      strokeWidth: currentStrokeWidth,
-      opacity:     current.opacity,
+      count:       100,
+      jitter:      78,
+      strokeWidth: visibleStrokeWidth,
+      opacity:     visibleOpacity,
       color:       current.color,
     } satisfies VoronoiConfig;
   }
@@ -269,19 +305,19 @@ function switchGeneratorType(current: GeneratorConfig, toType: GeneratorType): G
     return {
       type:    'strange-attractor',
       seed:    current.seed,
-      opacity: current.opacity,
+      opacity: visibleOpacity,
       color:   current.color,
     } satisfies StrangeAttractorConfig;
   }
   return {
     type:        'flow-field',
     seed:        current.seed,
-    density:     180,
-    steps:       90,
-    scale:       Math.max(80, Math.min(600, currentScale)),
-    curl:        0,
-    strokeWidth: currentStrokeWidth,
-    opacity:     current.opacity,
+    density:     260,
+    steps:       130,
+    scale:       Math.max(80, Math.min(420, currentScale)),
+    curl:        28,
+    strokeWidth: visibleStrokeWidth,
+    opacity:     visibleOpacity,
     color:       current.color,
   } satisfies FlowFieldConfig;
 }
@@ -294,8 +330,8 @@ function randomFlowField(): FlowFieldConfig {
     steps:       ri(40, 160),
     scale:       ri(100, 500),
     curl:        ri(-60, 60),
-    strokeWidth: rf(0.4, 1.4),
-    opacity:     ri(25, 60),
+    strokeWidth: rf(0.9, 1.8),
+    opacity:     ri(72, 100),
     color:       pick(COLORS).value,
   };
 }
@@ -306,8 +342,8 @@ function randomDotGrid(): DotGridConfig {
     seed:    ri(1, 999),
     spacing: ri(12, 36),
     scale:   ri(150, 500),
-    dotSize: ri(50, 95),
-    opacity: ri(30, 70),
+    dotSize: ri(72, 100),
+    opacity: ri(72, 100),
     color:   pick(COLORS).value,
   };
 }
@@ -318,8 +354,8 @@ function randomIsoline(): IsolineConfig {
     seed:        ri(1, 999),
     levels:      ri(5, 18),
     scale:       ri(150, 500),
-    strokeWidth: rf(0.4, 1.5),
-    opacity:     ri(30, 70),
+    strokeWidth: rf(0.9, 1.9),
+    opacity:     ri(72, 100),
     color:       pick(COLORS).value,
   };
 }
@@ -330,8 +366,8 @@ function randomVoronoi(): VoronoiConfig {
     seed:        ri(1, 999),
     count:       ri(40, 160),
     jitter:      ri(50, 100),
-    strokeWidth: rf(0.3, 1.2),
-    opacity:     ri(25, 65),
+    strokeWidth: rf(0.8, 1.7),
+    opacity:     ri(70, 100),
     color:       pick(COLORS).value,
   };
 }
@@ -340,7 +376,7 @@ function randomStrangeAttractor(): StrangeAttractorConfig {
   return {
     type:    'strange-attractor',
     seed:    ri(1, 999),
-    opacity: ri(40, 80),
+    opacity: ri(76, 100),
     color:   pick(COLORS).value,
   };
 }
@@ -519,6 +555,8 @@ export default function EditorialArtTool() {
   const panelScrollIdleRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const [scale, setScale]             = useState(0.6);
   const [downloading, setDownloading] = useState(false);
+  const [exportingStill, setExportingStill] = useState(false);
+  const [motionReplayKey, setMotionReplayKey] = useState(0);
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const [generatorMenuOpen, setGeneratorMenuOpen] = useState(false);
   const [panelScrolling, setPanelScrolling] = useState(false);
@@ -544,6 +582,7 @@ export default function EditorialArtTool() {
           ...defaultState(patch.themeId),
           title: prev.title, slug: prev.slug,
           slugEdited: prev.slugEdited, showText: prev.showText,
+          motion: prev.motion,
         };
       }
       return { ...prev, ...patch };
@@ -649,7 +688,10 @@ export default function EditorialArtTool() {
   const handleDownload = useCallback(async () => {
     if (!canvasRef.current) return;
     setDownloading(true);
+    setExportingStill(true);
     try {
+      await new Promise(requestAnimationFrame);
+      await new Promise(requestAnimationFrame);
       await document.fonts.ready;
       const dataUrl = await toPng(canvasRef.current, { pixelRatio: 2 });
       const a = document.createElement('a');
@@ -657,6 +699,7 @@ export default function EditorialArtTool() {
       a.href = dataUrl;
       a.click();
     } finally {
+      setExportingStill(false);
       setDownloading(false);
     }
   }, [state.slug]);
@@ -882,6 +925,41 @@ export default function EditorialArtTool() {
             <SliderRow label="Opacity" value={generator.opacity} min={0} max={100} onChange={(v) => patchGenerator({ opacity: v })} />
               </PanelSection>
 
+              <PanelSection title="Motion">
+            <SettingsRow label="Mode">
+              <SegmentedControl
+                value={state.motion.mode}
+                options={MOTION_MODES}
+                onChange={(mode) => {
+                  if (mode === 'reveal' && state.motion.mode === 'reveal') {
+                    setMotionReplayKey((key) => key + 1);
+                    return;
+                  }
+                  set({ motion: motionWithObviousDefaults(state.motion, mode) });
+                }}
+              />
+            </SettingsRow>
+            <SliderRow
+              label="Speed"
+              value={state.motion.speed}
+              min={0}
+              max={100}
+              onChange={(speed) => set({ motion: { ...state.motion, speed } })}
+            />
+            <SliderRow
+              label="Intensity"
+              value={state.motion.intensity}
+              min={0}
+              max={100}
+              onChange={(intensity) => set({ motion: { ...state.motion, intensity } })}
+            />
+            {state.motion.mode === 'ambient' && !['dot-grid', 'isoline'].includes(generator.type) && (
+              <p className="font-mono text-[10px] text-muted-foreground/60 leading-relaxed">
+                Ambient motion is active for Dot Grid and Isoline in this pass.
+              </p>
+            )}
+              </PanelSection>
+
               <PanelSection title="Canvas Style">
             <SettingsRow label="Color">
               <div className="flex items-center gap-3 rounded-md bg-muted px-2 py-2">
@@ -1038,6 +1116,8 @@ export default function EditorialArtTool() {
             showText={state.showText}
             composition={state.composition}
             textFont={state.textFont}
+            motion={exportingStill ? staticMotion : state.motion}
+            motionReplayKey={motionReplayKey}
           />
         </div>
       </div>

--- a/src/lab/editorial-art/index.tsx
+++ b/src/lab/editorial-art/index.tsx
@@ -85,6 +85,12 @@ const MOTION_MODES: { value: MotionMode; label: string }[] = [
   { value: 'ambient', label: 'Ambient' },
 ];
 
+const MOTION_PRESETS = [
+  { label: 'Subtle', speed: 36, intensity: 24 },
+  { label: 'Visible', speed: 64, intensity: 52 },
+  { label: 'Stress', speed: 92, intensity: 90 },
+] as const;
+
 const SURFACE_PRESETS = [
   { label: 'Off', value: 0 },
   { label: 'Soft', value: 35 },
@@ -173,6 +179,10 @@ function parseMotion(params: URLSearchParams, fallback: MotionConfig): MotionCon
     speed: Math.max(0, Math.min(100, numberParam(params, 'motionSpeed', fallback.speed))),
     intensity: Math.max(0, Math.min(100, numberParam(params, 'motionIntensity', fallback.intensity))),
   };
+}
+
+function supportsAmbientMotion(type: GeneratorType): boolean {
+  return type !== 'voronoi';
 }
 
 function motionWithObviousDefaults(current: MotionConfig, mode: MotionMode): MotionConfig {
@@ -953,9 +963,25 @@ export default function EditorialArtTool() {
               max={100}
               onChange={(intensity) => set({ motion: { ...state.motion, intensity } })}
             />
-            {state.motion.mode === 'ambient' && !['dot-grid', 'isoline'].includes(generator.type) && (
+            {state.motion.mode === 'ambient' && (
+              <SettingsRow label="Preset">
+                <div className="flex rounded-md bg-muted p-0.5">
+                  {MOTION_PRESETS.map((preset) => (
+                    <button
+                      key={preset.label}
+                      type="button"
+                      onClick={() => set({ motion: { ...state.motion, speed: preset.speed, intensity: preset.intensity } })}
+                      className="flex-1 cursor-pointer rounded-[5px] border border-transparent py-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      {preset.label}
+                    </button>
+                  ))}
+                </div>
+              </SettingsRow>
+            )}
+            {state.motion.mode === 'ambient' && !supportsAmbientMotion(generator.type) && (
               <p className="font-mono text-[10px] text-muted-foreground/60 leading-relaxed">
-                Ambient motion is active for Dot Grid and Isoline in this pass.
+                Voronoi stays static in Ambient for this pass. Use Reveal to test its motion.
               </p>
             )}
               </PanelSection>
@@ -1067,7 +1093,7 @@ export default function EditorialArtTool() {
               {downloading ? 'Generating…' : 'Download PNG'}
             </button>
             <p className="font-mono text-[10px] text-muted-foreground/60">
-              1200 × 630 · 2× export = 2400 × 1260 px
+              1200 × 630 · exports use the canonical static frame
             </p>
               </PanelSection>
             </div>

--- a/src/lab/editorial-art/index.tsx
+++ b/src/lab/editorial-art/index.tsx
@@ -80,22 +80,10 @@ const TEXT_FONTS: { value: TextFont; label: string }[] = [
 ];
 
 const MOTION_MODES: { value: MotionMode; label: string }[] = [
-  { value: 'static',  label: 'Static'  },
+  { value: 'static',  label: 'Off'     },
   { value: 'reveal',  label: 'Reveal'  },
   { value: 'ambient', label: 'Ambient' },
 ];
-
-const MOTION_PRESETS = [
-  { label: 'Subtle', speed: 36, intensity: 24 },
-  { label: 'Visible', speed: 64, intensity: 52 },
-  { label: 'Stress', speed: 92, intensity: 90 },
-] as const;
-
-const SURFACE_PRESETS = [
-  { label: 'Off', value: 0 },
-  { label: 'Soft', value: 35 },
-  { label: 'Heavy', value: 75 },
-] as const;
 
 const SCROLL_THUMB_INSET = 8;
 
@@ -444,35 +432,6 @@ function SegmentedControl<T extends string>({
   );
 }
 
-function PresetButtons({
-  label, value, onChange,
-}: {
-  label: string;
-  value: number;
-  onChange: (v: number) => void;
-}) {
-  return (
-    <div className="flex rounded-md bg-muted p-0.5">
-      {SURFACE_PRESETS.map((preset) => (
-        <button
-          key={preset.label}
-          type="button"
-          aria-label={`${label} ${preset.label}`}
-          onClick={() => onChange(preset.value)}
-          className={[
-            'flex-1 cursor-pointer rounded-[5px] border border-transparent py-1.5 font-mono text-[11px] transition-colors',
-            value === preset.value
-              ? 'border-border bg-background text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground',
-          ].join(' ')}
-        >
-          {preset.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 function SliderRow({
   label, value, min, max, step = 1, onChange, format,
 }: {
@@ -554,7 +513,6 @@ function SettingsRow({
 export default function EditorialArtTool() {
   const canvasRef    = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const themeMenuRef = useRef<HTMLDivElement>(null);
   const generatorMenuRef = useRef<HTMLDivElement>(null);
   const panelScrollRef = useRef<HTMLDivElement>(null);
   const panelContentRef = useRef<HTMLDivElement>(null);
@@ -563,7 +521,6 @@ export default function EditorialArtTool() {
   const [downloading, setDownloading] = useState(false);
   const [exportingStill, setExportingStill] = useState(false);
   const [motionReplayKey, setMotionReplayKey] = useState(0);
-  const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const [generatorMenuOpen, setGeneratorMenuOpen] = useState(false);
   const [panelScrolling, setPanelScrolling] = useState(false);
   const [panelScrollThumb, setPanelScrollThumb] = useState({ height: 0, top: 0, visible: false });
@@ -662,17 +619,6 @@ export default function EditorialArtTool() {
   }, [updatePanelScrollThumb]);
 
   useEffect(() => {
-    if (!themeMenuOpen) return;
-    const handlePointerDown = (event: PointerEvent) => {
-      if (!themeMenuRef.current?.contains(event.target as Node)) {
-        setThemeMenuOpen(false);
-      }
-    };
-    window.addEventListener('pointerdown', handlePointerDown);
-    return () => window.removeEventListener('pointerdown', handlePointerDown);
-  }, [themeMenuOpen]);
-
-  useEffect(() => {
     if (!generatorMenuOpen) return;
     const handlePointerDown = (event: PointerEvent) => {
       if (!generatorMenuRef.current?.contains(event.target as Node)) {
@@ -746,70 +692,6 @@ export default function EditorialArtTool() {
             className="h-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           >
             <div ref={panelContentRef}>
-              <PanelSection title="Theme">
-            <div ref={themeMenuRef} className="relative">
-              <button
-                type="button"
-                aria-label="Theme selector"
-                aria-haspopup="listbox"
-                aria-expanded={themeMenuOpen}
-                onClick={() => setThemeMenuOpen((open) => !open)}
-                className="flex h-9 w-full cursor-pointer items-center justify-between rounded-md border border-transparent bg-muted px-3 font-mono text-[12px] text-foreground focus:border-border focus:bg-background focus:outline-none"
-              >
-                <span>{themes[state.themeId].label}</span>
-                <ChevronDown className="size-4 text-foreground" strokeWidth={2} />
-              </button>
-
-              {themeMenuOpen && (
-                <div
-                  role="listbox"
-                  className="absolute left-0 right-0 top-[calc(100%+4px)] z-20 rounded-md border border-border bg-background p-1 shadow-lg"
-                >
-                  {Object.values(themes).map((theme) => {
-                    const active = theme.id === state.themeId;
-                    return (
-                      <button
-                        key={theme.id}
-                        type="button"
-                        role="option"
-                        aria-selected={active}
-                        onClick={() => {
-                          set({ themeId: theme.id });
-                          setThemeMenuOpen(false);
-                        }}
-                        className={[
-                          'flex w-full cursor-pointer items-center rounded-[5px] px-2.5 py-2 text-left font-mono text-[12px] transition-colors',
-                          active
-                            ? 'bg-foreground text-background'
-                            : 'text-foreground hover:bg-muted',
-                        ].join(' ')}
-                      >
-                        {theme.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-              <SegmentedControl
-                value={isColorDark(state.bgColor) ? 'dark' : 'light'}
-                options={[
-                  { value: 'dark',  label: 'Dark'  },
-                  { value: 'light', label: 'Light' },
-                ]}
-                onChange={(tone) => {
-                  setState((prev) => ({
-                    ...prev,
-                    bgColor: tone === 'dark' ? brand.warmDarkGray : brand.paper,
-                    generator: {
-                      ...prev.generator,
-                      color: tone === 'dark' ? 'copper' : 'bronze',
-                    } as GeneratorConfig,
-                  }));
-                }}
-              />
-              </PanelSection>
-
               <PanelSection title="Generator">
             {/* Foundation type picker */}
             <div ref={generatorMenuRef} className="relative">
@@ -903,13 +785,6 @@ export default function EditorialArtTool() {
               <SliderRow label="Jitter" value={generator.jitter} min={0}  max={100} onChange={(v) => patchGenerator({ jitter: v })} />
             </>)}
 
-            {/* Strange Attractor — seed is the creative control; no extra params needed */}
-            {generator.type === 'strange-attractor' && (
-              <p className="font-mono text-[10px] text-muted-foreground/60 leading-relaxed">
-                Clifford attractor. Each seed maps to a unique orbit.
-              </p>
-            )}
-
             {/* Scale — shared by flow-field, dot-grid, isoline (not voronoi/strange-attractor) */}
             {'scale' in generator && (
               <SliderRow label="Scale" value={(generator as { scale: number }).scale} min={generator.type === 'flow-field' ? 80 : 100} max={600} onChange={(v) => patchGenerator({ scale: v })} />
@@ -926,9 +801,6 @@ export default function EditorialArtTool() {
               <SliderRow label="Weight" value={generator.strokeWidth} min={0.3} max={2.0} step={0.1} onChange={(v) => patchGenerator({ strokeWidth: v })} />
             )}
 
-            {/* Color + Opacity — shared */}
-            <ColorDots value={generator.color} onChange={(v) => patchGenerator({ color: v })} bgColor={bgColor} />
-            <SliderRow label="Opacity" value={generator.opacity} min={0} max={100} onChange={(v) => patchGenerator({ opacity: v })} />
               </PanelSection>
 
               <PanelSection title="Motion">
@@ -945,40 +817,47 @@ export default function EditorialArtTool() {
                 }}
               />
             </SettingsRow>
-            <SliderRow
-              label="Speed"
-              value={state.motion.speed}
-              min={0}
-              max={100}
-              onChange={(speed) => set({ motion: { ...state.motion, speed } })}
-            />
-            <SliderRow
-              label="Intensity"
-              value={state.motion.intensity}
-              min={0}
-              max={100}
-              onChange={(intensity) => set({ motion: { ...state.motion, intensity } })}
-            />
             {state.motion.mode === 'ambient' && (
-              <SettingsRow label="Preset">
-                <div className="flex rounded-md bg-muted p-0.5">
-                  {MOTION_PRESETS.map((preset) => (
-                    <button
-                      key={preset.label}
-                      type="button"
-                      onClick={() => set({ motion: { ...state.motion, speed: preset.speed, intensity: preset.intensity } })}
-                      className="flex-1 cursor-pointer rounded-[5px] border border-transparent py-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                      {preset.label}
-                    </button>
-                  ))}
-                </div>
-              </SettingsRow>
+              <>
+                <SliderRow
+                  label="Speed"
+                  value={state.motion.speed}
+                  min={0}
+                  max={100}
+                  onChange={(speed) => set({ motion: { ...state.motion, speed } })}
+                />
+                <SliderRow
+                  label="Intensity"
+                  value={state.motion.intensity}
+                  min={0}
+                  max={100}
+                  onChange={(intensity) => set({ motion: { ...state.motion, intensity } })}
+                />
+              </>
             )}
               </PanelSection>
 
-              <PanelSection title="Canvas Style">
-            <SettingsRow label="Color">
+              <PanelSection title="Appearance">
+            <SettingsRow label="Tone">
+              <SegmentedControl
+                value={isColorDark(state.bgColor) ? 'dark' : 'light'}
+                options={[
+                  { value: 'dark',  label: 'Dark'  },
+                  { value: 'light', label: 'Light' },
+                ]}
+                onChange={(tone) => {
+                  setState((prev) => ({
+                    ...prev,
+                    bgColor: tone === 'dark' ? brand.warmDarkGray : brand.paper,
+                    generator: {
+                      ...prev.generator,
+                      color: tone === 'dark' ? 'copper' : 'bronze',
+                    } as GeneratorConfig,
+                  }));
+                }}
+              />
+            </SettingsRow>
+            <SettingsRow label="Surface">
               <div className="flex items-center gap-3 rounded-md bg-muted px-2 py-2">
                 {bgPalette.map((s) => (
                   <button
@@ -997,28 +876,10 @@ export default function EditorialArtTool() {
                 ))}
               </div>
             </SettingsRow>
-            <SettingsRow label="Caption">
-              <SegmentedControl
-                value={state.showCaption ? 'on' : 'off'}
-                options={[
-                  { value: 'off', label: 'Off' },
-                  { value: 'on', label: 'On' },
-                ]}
-                onChange={(value) => set({ showCaption: value === 'on' })}
-              />
-            </SettingsRow>
-            <div className="space-y-2">
-              <SliderRow label="Texture" value={state.texture} min={0} max={100} onChange={(v) => set({ texture: v })} />
-              <SettingsRow label="">
-                <PresetButtons label="Texture" value={state.texture} onChange={(v) => set({ texture: v })} />
-              </SettingsRow>
-            </div>
-            <div className="space-y-2">
-              <SliderRow label="Grain" value={state.grain} min={0} max={100} onChange={(v) => set({ grain: v })} />
-              <SettingsRow label="">
-                <PresetButtons label="Grain" value={state.grain} onChange={(v) => set({ grain: v })} />
-              </SettingsRow>
-            </div>
+            <ColorDots value={generator.color} onChange={(v) => patchGenerator({ color: v })} bgColor={bgColor} />
+            <SliderRow label="Opacity" value={generator.opacity} min={0} max={100} onChange={(v) => patchGenerator({ opacity: v })} />
+            <SliderRow label="Texture" value={state.texture} min={0} max={100} onChange={(v) => set({ texture: v })} />
+            <SliderRow label="Grain" value={state.grain} min={0} max={100} onChange={(v) => set({ grain: v })} />
               </PanelSection>
 
               <PanelSection
@@ -1062,6 +923,16 @@ export default function EditorialArtTool() {
                   options={COMPOSITIONS}
                   onChange={(composition) => set({ composition })}
                 />
+                <SettingsRow label="Caption">
+                  <SegmentedControl
+                    value={state.showCaption ? 'on' : 'off'}
+                    options={[
+                      { value: 'off', label: 'Off' },
+                      { value: 'on', label: 'On' },
+                    ]}
+                    onChange={(value) => set({ showCaption: value === 'on' })}
+                  />
+                </SettingsRow>
               </>
             )}
               </PanelSection>

--- a/src/lab/editorial-art/themes.ts
+++ b/src/lab/editorial-art/themes.ts
@@ -2,6 +2,7 @@ export type ThemeId = 'ai' | 'design' | 'systems' | 'creative' | 'career';
 export type Composition = 'centered' | 'left' | 'offset';
 export type LayerColor = 'copper' | 'light' | 'dark' | 'muted' | 'sage' | 'bronze';
 export type TextFont = 'sans' | 'mono' | 'pixel';
+export type MotionMode = 'static' | 'reveal' | 'ambient';
 
 export const CANVAS_W = 1200;
 export const CANVAS_H = 630;
@@ -25,6 +26,29 @@ export const bgPalette = [
   { name: 'Cream', value: brand.offWhite,     dark: false },
   { name: 'Dark',  value: brand.warmDarkGray, dark: true  },
 ] as const;
+
+export interface MotionConfig {
+  mode: MotionMode;
+  speed: number;
+  intensity: number;
+}
+
+export interface RenderContext {
+  progress: number;
+  time: number;
+  motion: MotionConfig;
+}
+
+export const staticMotion: MotionConfig = {
+  mode: 'static',
+  speed: 72,
+  intensity: 58,
+};
+
+export const revealMotion: MotionConfig = {
+  ...staticMotion,
+  mode: 'reveal',
+};
 
 export function isColorDark(hex: string): boolean {
   const r = parseInt(hex.slice(1, 3), 16);
@@ -121,7 +145,7 @@ export const themeList: ThemeConfig[] = [
     id: 'ai',
     label: 'AI',
     defaultBgColor: brand.warmDarkGray,
-    defaultGenerator: { type: 'strange-attractor', seed: 42,  opacity: 85, color: 'copper' },
+    defaultGenerator: { type: 'strange-attractor', seed: 42,  opacity: 98, color: 'copper' },
     defaultTexture: 20,
     defaultComposition: 'left',
   },
@@ -129,7 +153,7 @@ export const themeList: ThemeConfig[] = [
     id: 'design',
     label: 'Design',
     defaultBgColor: brand.warmDarkGray,
-    defaultGenerator: { type: 'isoline',           seed: 137, levels: 12, scale: 350, strokeWidth: 0.7, opacity: 75, color: 'copper' },
+    defaultGenerator: { type: 'isoline',           seed: 137, levels: 14, scale: 300, strokeWidth: 1.2, opacity: 96, color: 'copper' },
     defaultTexture: 0,
     defaultComposition: 'left',
   },
@@ -137,7 +161,7 @@ export const themeList: ThemeConfig[] = [
     id: 'systems',
     label: 'Systems',
     defaultBgColor: brand.warmDarkGray,
-    defaultGenerator: { type: 'voronoi',            seed: 73,  count: 60, jitter: 60, strokeWidth: 0.6, opacity: 75, color: 'copper' },
+    defaultGenerator: { type: 'voronoi',            seed: 73,  count: 88, jitter: 70, strokeWidth: 1.1, opacity: 94, color: 'copper' },
     defaultTexture: 0,
     defaultComposition: 'left',
   },
@@ -145,7 +169,7 @@ export const themeList: ThemeConfig[] = [
     id: 'creative',
     label: 'Creative Practice',
     defaultBgColor: brand.warmDarkGray,
-    defaultGenerator: { type: 'flow-field',         seed: 256, density: 150, steps: 100, scale: 320, curl: 30, strokeWidth: 1.0, opacity: 75, color: 'copper' },
+    defaultGenerator: { type: 'flow-field',         seed: 256, density: 240, steps: 130, scale: 260, curl: 36, strokeWidth: 1.25, opacity: 94, color: 'copper' },
     defaultTexture: 20,
     defaultComposition: 'centered',
   },
@@ -153,7 +177,7 @@ export const themeList: ThemeConfig[] = [
     id: 'career',
     label: 'Career',
     defaultBgColor: brand.warmDarkGray,
-    defaultGenerator: { type: 'dot-grid',           seed: 512, spacing: 22, scale: 300, dotSize: 70, opacity: 70, color: 'copper' },
+    defaultGenerator: { type: 'dot-grid',           seed: 512, spacing: 18, scale: 240, dotSize: 92, opacity: 96, color: 'copper' },
     defaultTexture: 0,
     defaultComposition: 'left',
   },

--- a/src/lab/editorial-art/useGenerativeCanvas.ts
+++ b/src/lab/editorial-art/useGenerativeCanvas.ts
@@ -50,7 +50,7 @@ function renderData(
   } else if (config.type === 'isoline' && generated.type === 'isoline') {
     drawIsolines(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render);
   } else if (config.type === 'voronoi' && generated.type === 'voronoi') {
-    drawVoronoi(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render.progress);
+    drawVoronoi(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render);
   } else if (config.type === 'strange-attractor' && generated.type === 'strange-attractor') {
     drawAttractor(ctx, generated.data, color, config.opacity, w, h, render);
   }

--- a/src/lab/editorial-art/useGenerativeCanvas.ts
+++ b/src/lab/editorial-art/useGenerativeCanvas.ts
@@ -60,6 +60,7 @@ function renderData(
 export interface UseGenerativeCanvasOptions {
   animate?: boolean;   // play draw-in animation on mount/data change
   duration?: number;   // animation duration in ms (default 2500)
+  transparentBackground?: boolean;
 }
 
 export function useGenerativeCanvas(
@@ -70,6 +71,7 @@ export function useGenerativeCanvas(
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animate = opts?.animate ?? false;
   const duration = opts?.duration ?? 2500;
+  const transparentBackground = opts?.transparentBackground ?? false;
 
   // Regenerate data only when structural params change
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -82,6 +84,8 @@ export function useGenerativeCanvas(
   configRef.current = config;
   const bgColorRef = useRef(bgColor);
   bgColorRef.current = bgColor;
+  const transparentBackgroundRef = useRef(transparentBackground);
+  transparentBackgroundRef.current = transparentBackground;
   // Tracks the last rendered progress so ResizeObserver and color changes redraw correctly
   const progressRef = useRef(animate ? 0 : 1);
 
@@ -97,8 +101,10 @@ export function useGenerativeCanvas(
 
     progressRef.current = p;
     ctx.clearRect(0, 0, w, h);
-    ctx.fillStyle = bgColorRef.current;
-    ctx.fillRect(0, 0, w, h);
+    if (!transparentBackgroundRef.current) {
+      ctx.fillStyle = bgColorRef.current;
+      ctx.fillRect(0, 0, w, h);
+    }
     renderData(ctx, generatedRef.current, configRef.current, w, h, p);
   }, []);
 
@@ -131,7 +137,7 @@ export function useGenerativeCanvas(
   // without restarting animation
   useEffect(() => {
     redraw(progressRef.current);
-  }, [config, bgColor, redraw]);
+  }, [config, bgColor, transparentBackground, redraw]);
 
   // Resize canvas to match container in device pixels, then redraw
   useEffect(() => {

--- a/src/lab/editorial-art/useGenerativeCanvas.ts
+++ b/src/lab/editorial-art/useGenerativeCanvas.ts
@@ -44,7 +44,7 @@ function renderData(
 ): void {
   const color = resolveLayerColor(config.color);
   if (config.type === 'flow-field' && generated.type === 'flow-field') {
-    drawFlowField(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render.progress);
+    drawFlowField(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render);
   } else if (config.type === 'dot-grid' && generated.type === 'dot-grid') {
     drawDotGrid(ctx, generated.data, color, config.opacity, w, h, render);
   } else if (config.type === 'isoline' && generated.type === 'isoline') {
@@ -52,7 +52,7 @@ function renderData(
   } else if (config.type === 'voronoi' && generated.type === 'voronoi') {
     drawVoronoi(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render.progress);
   } else if (config.type === 'strange-attractor' && generated.type === 'strange-attractor') {
-    drawAttractor(ctx, generated.data, color, config.opacity, w, h, render.progress);
+    drawAttractor(ctx, generated.data, color, config.opacity, w, h, render);
   }
 }
 

--- a/src/lab/editorial-art/useGenerativeCanvas.ts
+++ b/src/lab/editorial-art/useGenerativeCanvas.ts
@@ -1,6 +1,5 @@
-import { useRef, useEffect, useMemo, useCallback } from 'react';
-import type { RefObject } from 'react';
-import { type GeneratorConfig, resolveLayerColor } from './themes';
+import { useRef, useEffect, useMemo, useCallback, type RefObject } from 'react';
+import { staticMotion, type GeneratorConfig, type MotionConfig, type RenderContext, resolveLayerColor } from './themes';
 import { generateFlowField, drawFlowField, type FlowPath } from './generators/flowField';
 import { generateDotGrid, drawDotGrid, type Dot } from './generators/dotGrid';
 import { generateIsolines, drawIsolines, type IsolineLevel } from './generators/isoline';
@@ -41,24 +40,24 @@ function renderData(
   config: GeneratorConfig,
   w: number,
   h: number,
-  progress: number,
+  render: RenderContext,
 ): void {
   const color = resolveLayerColor(config.color);
   if (config.type === 'flow-field' && generated.type === 'flow-field') {
-    drawFlowField(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, progress);
+    drawFlowField(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render.progress);
   } else if (config.type === 'dot-grid' && generated.type === 'dot-grid') {
-    drawDotGrid(ctx, generated.data, color, config.opacity, w, h, progress);
+    drawDotGrid(ctx, generated.data, color, config.opacity, w, h, render);
   } else if (config.type === 'isoline' && generated.type === 'isoline') {
-    drawIsolines(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, progress);
+    drawIsolines(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render);
   } else if (config.type === 'voronoi' && generated.type === 'voronoi') {
-    drawVoronoi(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, progress);
+    drawVoronoi(ctx, generated.data, color, config.opacity, config.strokeWidth, w, h, render.progress);
   } else if (config.type === 'strange-attractor' && generated.type === 'strange-attractor') {
-    drawAttractor(ctx, generated.data, color, config.opacity, w, h, progress);
+    drawAttractor(ctx, generated.data, color, config.opacity, w, h, render.progress);
   }
 }
 
 export interface UseGenerativeCanvasOptions {
-  animate?: boolean;   // play draw-in animation on mount/data change
+  motion?: MotionConfig;
   duration?: number;   // animation duration in ms (default 2500)
   transparentBackground?: boolean;
 }
@@ -67,9 +66,9 @@ export function useGenerativeCanvas(
   config: GeneratorConfig,
   bgColor: string,
   opts?: UseGenerativeCanvasOptions,
-): { canvasRef: RefObject<HTMLCanvasElement> } {
+): { canvasRef: RefObject<HTMLCanvasElement | null> } {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const animate = opts?.animate ?? false;
+  const motion = opts?.motion ?? staticMotion;
   const duration = opts?.duration ?? 2500;
   const transparentBackground = opts?.transparentBackground ?? false;
 
@@ -86,11 +85,16 @@ export function useGenerativeCanvas(
   bgColorRef.current = bgColor;
   const transparentBackgroundRef = useRef(transparentBackground);
   transparentBackgroundRef.current = transparentBackground;
-  // Tracks the last rendered progress so ResizeObserver and color changes redraw correctly
-  const progressRef = useRef(animate ? 0 : 1);
+  const motionRef = useRef(motion);
+  motionRef.current = motion;
+  const renderRef = useRef<RenderContext>({
+    progress: motion.mode === 'reveal' ? 0 : 1,
+    time: 0,
+    motion,
+  });
 
   // Stable redraw — always reads from refs, safe to use inside ResizeObserver/RAF
-  const redraw = useCallback((p: number) => {
+  const redraw = useCallback((render: RenderContext) => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
@@ -99,13 +103,13 @@ export function useGenerativeCanvas(
     const h = canvas.height;
     if (w === 0 || h === 0) return;
 
-    progressRef.current = p;
+    renderRef.current = render;
     ctx.clearRect(0, 0, w, h);
     if (!transparentBackgroundRef.current) {
       ctx.fillStyle = bgColorRef.current;
       ctx.fillRect(0, 0, w, h);
     }
-    renderData(ctx, generatedRef.current, configRef.current, w, h, p);
+    renderData(ctx, generatedRef.current, configRef.current, w, h, render);
   }, []);
 
   // Draw/animate effect: restarts when generated data changes (seed or structural params)
@@ -114,30 +118,43 @@ export function useGenerativeCanvas(
       typeof window !== 'undefined' &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    if (!animate || prefersReduced) {
-      redraw(1);
+    const activeMotion = motionRef.current;
+
+    if (prefersReduced || activeMotion.mode === 'static') {
+      redraw({ progress: 1, time: 0, motion: activeMotion });
       return;
     }
 
     let rafId: number;
     let startTime: number | null = null;
 
+    if (activeMotion.mode === 'ambient') {
+      const tick = (ts: number) => {
+        if (!startTime) startTime = ts;
+        redraw({ progress: 1, time: ts - startTime, motion: motionRef.current });
+        rafId = requestAnimationFrame(tick);
+      };
+
+      rafId = requestAnimationFrame(tick);
+      return () => cancelAnimationFrame(rafId);
+    }
+
     function tick(ts: number) {
       if (!startTime) startTime = ts;
       const p = Math.min((ts - startTime) / duration, 1);
-      redraw(p);
+      redraw({ progress: p, time: 0, motion: motionRef.current });
       if (p < 1) rafId = requestAnimationFrame(tick);
     }
 
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, [generated, animate, duration, redraw]);
+  }, [generated, motion.mode, duration, redraw]);
 
   // Re-render at current progress when visual style (color/opacity/strokeWidth/bg) changes
   // without restarting animation
   useEffect(() => {
-    redraw(progressRef.current);
-  }, [config, bgColor, transparentBackground, redraw]);
+    redraw({ ...renderRef.current, motion });
+  }, [config, bgColor, transparentBackground, motion, redraw]);
 
   // Resize canvas to match container in device pixels, then redraw
   useEffect(() => {
@@ -153,7 +170,7 @@ export function useGenerativeCanvas(
         canvas.height = Math.round(height * dpr);
         canvas.style.width = `${width}px`;
         canvas.style.height = `${height}px`;
-        redraw(progressRef.current);
+        redraw(renderRef.current);
       }
     });
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import ProjectCard from "@/components/ProjectCard.astro";
 import PixelWaveText from "@/components/PixelWaveText.astro";
 import LabCard from "@/components/lab/LabCard.astro";
 import { GenerativePatternSurface } from "@/lab/editorial-art/GenerativePatternSurface";
+import { UAMark } from "@/lab/editorial-art/UAMark";
 import { siteConfig } from "@/data/site-config";
 import { commendations } from "@/data/commendations";
 import { getCollection } from "astro:content";
@@ -42,111 +43,94 @@ const impactStatements: Record<string, string> = {
 };
 
 const newsletterPattern = {
-  type: "strange-attractor",
+  type: "dot-grid",
   seed: 88,
-  opacity: 88,
+  spacing: 18,
+  scale: 240,
+  dotSize: 70,
+  opacity: 72,
   color: "copper",
 } as const;
 
 const newsletterLightPattern = {
   ...newsletterPattern,
-  opacity: 100,
+  opacity: 64,
   color: "bronze",
 } as const;
 
-const heroTexturePattern = {
-  type: "isoline",
-  seed: 742,
-  levels: 18,
-  scale: 135,
-  strokeWidth: 0.55,
-  opacity: 56,
-  color: "copper",
+const newsletterMotion = {
+  mode: "ambient",
+  speed: 42,
+  intensity: 30,
 } as const;
 
-const heroTextureLightPattern = {
-  ...heroTexturePattern,
-  opacity: 38,
-  color: "bronze",
-  strokeWidth: 0.65,
-} as const;
 ---
 
 <PageLayout>
   {/* Hero */}
-  <section class="relative overflow-hidden">
-    <GenerativePatternSurface
-      name="home-hero-texture"
-      config={heroTexturePattern}
-      lightConfig={heroTextureLightPattern}
-      duration={3600}
-      className="absolute inset-x-0 top-0 h-[28rem] opacity-48 mix-blend-multiply [mask-image:linear-gradient(to_bottom,black_0%,black_30%,transparent_92%)] dark:opacity-72 dark:mix-blend-screen"
-      client:visible
-    />
-    <div class="relative z-10 mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24">
-      <div class="mb-8 flex items-center gap-6">
-        <img
-          src="/images/brand/profile-picture.jpg"
-          alt="Patrick Morgan"
-          class="h-20 w-20 rounded-full object-cover"
-          data-hero-photo
+  <section class="mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24">
+    <div class="mb-8 flex items-center gap-6">
+      <img
+        src="/images/brand/profile-picture.jpg"
+        alt="Patrick Morgan"
+        class="h-20 w-20 rounded-full object-cover"
+        data-hero-photo
+        style="opacity: 0;"
+      />
+      <div>
+        <p class="mb-1 font-mono text-sm text-muted-foreground" data-hero-label style="opacity: 0;">Software Designer</p>
+        <PixelWaveText
+          text="Patrick Morgan"
+          as="h1"
+          wave="hero"
+          class="text-3xl font-medium tracking-tight sm:text-5xl"
           style="opacity: 0;"
         />
-        <div>
-          <p class="mb-1 font-mono text-sm text-muted-foreground" data-hero-label style="opacity: 0;">Software Designer</p>
-          <PixelWaveText
-            text="Patrick Morgan"
-            as="h1"
-            wave="hero"
-            class="text-3xl font-medium tracking-tight sm:text-5xl"
-            style="opacity: 0;"
-          />
-        </div>
       </div>
-      <p class="mb-6 max-w-2xl text-md text-muted-foreground" data-hero-desc style="opacity: 0;">
-        Designing AI cybersecurity tools at
-        <a href="https://sublime.security" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Sublime Security</a> and publishing
-        <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Unknown Arts</a>
-        — a newsletter for creative builders in the age of AI.
-      </p>
-      <div class="flex items-center gap-3 text-muted-foreground" data-hero-icons style="opacity: 0;">
-        <a
-          href={siteConfig.social.newsletter}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="transition-colors hover:text-foreground"
-          aria-label="Substack"
-        >
-          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.6 8.242H1.46V5.406H20.6v2.836zM1.46 10.812V24l9.6-5.55 9.54 5.55V10.812H1.46zM20.6 0H1.46v2.836H20.6V0z"/></svg>
-        </a>
-        <a
-          href={siteConfig.social.linkedin}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="transition-colors hover:text-foreground"
-          aria-label="LinkedIn"
-        >
-          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
-        </a>
-        <a
-          href={siteConfig.social.x}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="transition-colors hover:text-foreground"
-          aria-label="X"
-        >
-          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-        </a>
-        <a
-          href={siteConfig.social.github}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="transition-colors hover:text-foreground"
-          aria-label="GitHub"
-        >
-          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
-        </a>
-      </div>
+    </div>
+    <p class="mb-6 max-w-2xl text-md text-muted-foreground" data-hero-desc style="opacity: 0;">
+      Designing AI cybersecurity tools at
+      <a href="https://sublime.security" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Sublime Security</a> and publishing
+      <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Unknown Arts</a>
+      — a newsletter for creative builders in the age of AI.
+    </p>
+    <div class="flex items-center gap-3 text-muted-foreground" data-hero-icons style="opacity: 0;">
+      <a
+        href={siteConfig.social.newsletter}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="transition-colors hover:text-foreground"
+        aria-label="Substack"
+      >
+        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.6 8.242H1.46V5.406H20.6v2.836zM1.46 10.812V24l9.6-5.55 9.54 5.55V10.812H1.46zM20.6 0H1.46v2.836H20.6V0z"/></svg>
+      </a>
+      <a
+        href={siteConfig.social.linkedin}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="transition-colors hover:text-foreground"
+        aria-label="LinkedIn"
+      >
+        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+      </a>
+      <a
+        href={siteConfig.social.x}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="transition-colors hover:text-foreground"
+        aria-label="X"
+      >
+        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+      </a>
+      <a
+        href={siteConfig.social.github}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="transition-colors hover:text-foreground"
+        aria-label="GitHub"
+      >
+        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+      </a>
     </div>
   </section>
 
@@ -230,7 +214,7 @@ const heroTextureLightPattern = {
     <h2 class="mb-8 font-mono text-xs uppercase tracking-widest text-muted-foreground">
       Writing
     </h2>
-    <div class="group mb-10 overflow-hidden rounded-lg border border-border transition-all duration-300 hover:shadow-lg hover:shadow-black/5 dark:hover:shadow-black/20" data-generative-pattern-trigger>
+    <div class="group mb-10 overflow-hidden rounded-lg border border-border transition-all duration-300 hover:shadow-lg hover:shadow-black/5 dark:hover:shadow-black/20">
       <a
         href={siteConfig.social.newsletter}
         target="_blank"
@@ -243,9 +227,9 @@ const heroTextureLightPattern = {
             name="unknown-arts-newsletter"
             config={newsletterPattern}
             lightConfig={newsletterLightPattern}
+            motion={newsletterMotion}
             duration={2800}
-            interactive
-            className="absolute inset-0 opacity-85 transition-opacity duration-300 group-hover:opacity-100"
+            className="absolute inset-0 opacity-90 transition-opacity duration-300 group-hover:opacity-95"
             client:visible
           />
           <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_72%_34%,transparent_0%,transparent_28%,var(--background)_82%)] opacity-35 dark:opacity-50"></div>
@@ -253,35 +237,32 @@ const heroTextureLightPattern = {
           <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/80 via-background/5 to-transparent dark:hidden"></div>
           <div class="pointer-events-none absolute bottom-5 left-5 right-5 flex items-end justify-between gap-6">
             <div>
-              <p class="mb-2 font-mono text-[10px] uppercase tracking-widest text-foreground/55 dark:text-[#ede9e3]/55">
+              <div class="mb-4 text-[#b38b6d] dark:text-[#f7ccab]">
+                <UAMark color="currentColor" height={34} />
+              </div>
+              <p class="text-4xl font-medium leading-none tracking-tight text-foreground dark:text-[#ede9e3] sm:text-6xl">
                 Unknown Arts
               </p>
-              <p class="max-w-sm text-2xl font-medium leading-tight tracking-tight text-foreground dark:text-[#ede9e3] sm:text-4xl">
-                Creative builders in the age of AI
+              <p class="mt-3 max-w-lg text-base leading-snug text-muted-foreground dark:text-[#ede9e3]/70 sm:text-lg">
+                The newsletter for creative builders in the age of AI.
               </p>
             </div>
-            <p class="hidden font-mono text-[10px] uppercase tracking-widest text-foreground/35 dark:text-[#ede9e3]/35 sm:block">
-              Seed 88
-            </p>
           </div>
         </div>
       </a>
-      <div class="p-5 sm:p-6">
-        <div class="mb-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-8">
-          <h3 class="text-lg font-semibold tracking-tight sm:flex-1">Unknown Arts Newsletter</h3>
-          <div class="flex gap-6 sm:shrink-0">
-            <div>
-              <p class="text-lg font-semibold tracking-tight">7,500+</p>
-              <p class="font-mono text-xs text-muted-foreground">Subscribers</p>
-            </div>
-            <div>
-              <p class="text-lg font-semibold tracking-tight">200+</p>
-              <p class="font-mono text-xs text-muted-foreground">Articles</p>
-            </div>
-            <div>
-              <p class="text-lg font-semibold tracking-tight">128</p>
-              <p class="font-mono text-xs text-muted-foreground">Countries</p>
-            </div>
+      <div class="border-t border-border bg-background/70 p-5 dark:bg-background/45 sm:p-6">
+        <div class="mb-4 flex max-w-md gap-8">
+          <div>
+            <p class="text-lg font-semibold tracking-tight">7,500+</p>
+            <p class="font-mono text-xs text-muted-foreground">Subscribers</p>
+          </div>
+          <div>
+            <p class="text-lg font-semibold tracking-tight">200+</p>
+            <p class="font-mono text-xs text-muted-foreground">Articles</p>
+          </div>
+          <div>
+            <p class="text-lg font-semibold tracking-tight">128</p>
+            <p class="font-mono text-xs text-muted-foreground">Countries</p>
           </div>
         </div>
         <p class="text-sm leading-relaxed text-muted-foreground">
@@ -296,7 +277,7 @@ const heroTextureLightPattern = {
       </div>
     </div>
     <div class="flex flex-col gap-2">
-      {writingPosts.slice(0, 4).map((post) => (
+      {writingPosts.slice(0, 3).map((post) => (
         <ArticleListItem
           id={post.id}
           title={post.data.title}
@@ -308,7 +289,6 @@ const heroTextureLightPattern = {
     </div>
     <div class="mt-8 flex items-center gap-6 text-sm">
       <a href="/writing" class="transition-colors hover:text-accent">View all articles &rarr;</a>
-      <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">Read the newsletter &rarr;</a>
     </div>
   </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,25 +43,26 @@ const impactStatements: Record<string, string> = {
 };
 
 const newsletterPattern = {
-  type: "dot-grid",
-  seed: 88,
-  spacing: 18,
-  scale: 240,
-  dotSize: 70,
-  opacity: 72,
+  type: "isoline",
+  seed: 211,
+  levels: 9,
+  scale: 340,
+  strokeWidth: 0.9,
+  opacity: 66,
   color: "copper",
 } as const;
 
 const newsletterLightPattern = {
   ...newsletterPattern,
-  opacity: 64,
+  opacity: 76,
+  strokeWidth: 1.05,
   color: "bronze",
 } as const;
 
 const newsletterMotion = {
   mode: "ambient",
-  speed: 42,
-  intensity: 30,
+  speed: 20,
+  intensity: 28,
 } as const;
 
 ---
@@ -214,7 +215,8 @@ const newsletterMotion = {
     <h2 class="mb-8 font-mono text-xs uppercase tracking-widest text-muted-foreground">
       Writing
     </h2>
-    <div class="group mb-10 overflow-hidden rounded-lg border border-border transition-all duration-300 hover:shadow-lg hover:shadow-black/5 dark:hover:shadow-black/20">
+    <div class="group mb-10">
+      <article class="overflow-hidden rounded-xl border border-border bg-card transition-all duration-300 group-hover:-translate-y-0.5 group-hover:shadow-md group-hover:shadow-black/5 dark:group-hover:shadow-black/20">
       <a
         href={siteConfig.social.newsletter}
         target="_blank"
@@ -222,19 +224,19 @@ const newsletterMotion = {
         class="block overflow-hidden"
         aria-label="Unknown Arts newsletter"
       >
-        <div class="relative aspect-video w-full overflow-hidden bg-card transition-transform duration-300 group-hover:scale-[1.01]">
+        <div class="relative aspect-video w-full overflow-hidden bg-card">
           <GenerativePatternSurface
             name="unknown-arts-newsletter"
             config={newsletterPattern}
             lightConfig={newsletterLightPattern}
             motion={newsletterMotion}
             duration={2800}
-            className="absolute inset-0 opacity-90 transition-opacity duration-300 group-hover:opacity-95"
+            className="absolute inset-0 opacity-95 transition-all duration-300 group-hover:scale-[1.03] group-hover:opacity-100"
             client:visible
           />
-          <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_72%_34%,transparent_0%,transparent_28%,var(--background)_82%)] opacity-35 dark:opacity-50"></div>
-          <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-[#171716]/90 via-[#171716]/10 to-transparent opacity-0 dark:opacity-100"></div>
-          <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/80 via-background/5 to-transparent dark:hidden"></div>
+          <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_72%_38%,transparent_0%,transparent_32%,var(--background)_86%)] opacity-10 dark:opacity-35"></div>
+          <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-[#171716]/92 via-[#171716]/12 to-transparent opacity-0 dark:opacity-100"></div>
+          <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/68 via-background/0 to-transparent dark:hidden"></div>
           <div class="pointer-events-none absolute bottom-5 left-5 right-5 flex items-end justify-between gap-6">
             <div>
               <div class="mb-4 text-[#b38b6d] dark:text-[#f7ccab]">
@@ -275,6 +277,7 @@ const newsletterMotion = {
           <a href="https://heydesigner.com" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">HeyDesigner</a>.
         </p>
       </div>
+      </article>
     </div>
     <div class="flex flex-col gap-2">
       {writingPosts.slice(0, 3).map((post) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import ArticleListItem from "@/components/ArticleListItem.astro";
 import ProjectCard from "@/components/ProjectCard.astro";
 import PixelWaveText from "@/components/PixelWaveText.astro";
 import LabCard from "@/components/lab/LabCard.astro";
+import { GenerativePatternSurface } from "@/lab/editorial-art/GenerativePatternSurface";
 import { siteConfig } from "@/data/site-config";
 import { commendations } from "@/data/commendations";
 import { getCollection } from "astro:content";
@@ -39,73 +40,113 @@ const impactStatements: Record<string, string> = {
   "expansion": "Established scalable product architecture that enabled rapid market expansion.",
   "vision": "Unified product teams around a shared vision driven by customer insights.",
 };
+
+const newsletterPattern = {
+  type: "strange-attractor",
+  seed: 88,
+  opacity: 88,
+  color: "copper",
+} as const;
+
+const newsletterLightPattern = {
+  ...newsletterPattern,
+  opacity: 100,
+  color: "bronze",
+} as const;
+
+const heroTexturePattern = {
+  type: "isoline",
+  seed: 742,
+  levels: 18,
+  scale: 135,
+  strokeWidth: 0.55,
+  opacity: 56,
+  color: "copper",
+} as const;
+
+const heroTextureLightPattern = {
+  ...heroTexturePattern,
+  opacity: 38,
+  color: "bronze",
+  strokeWidth: 0.65,
+} as const;
 ---
 
 <PageLayout>
   {/* Hero */}
-  <section class="mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24">
-    <div class="mb-8 flex items-center gap-6">
-      <img
-        src="/images/brand/profile-picture.jpg"
-        alt="Patrick Morgan"
-        class="h-20 w-20 rounded-full object-cover"
-        data-hero-photo
-        style="opacity: 0;"
-      />
-      <div>
-        <p class="mb-1 font-mono text-sm text-muted-foreground" data-hero-label style="opacity: 0;">Software Designer</p>
-        <PixelWaveText
-          text="Patrick Morgan"
-          as="h1"
-          wave="hero"
-          class="text-3xl font-medium tracking-tight sm:text-5xl"
+  <section class="relative overflow-hidden">
+    <GenerativePatternSurface
+      name="home-hero-texture"
+      config={heroTexturePattern}
+      lightConfig={heroTextureLightPattern}
+      duration={3600}
+      className="absolute inset-x-0 top-0 h-[28rem] opacity-48 mix-blend-multiply [mask-image:linear-gradient(to_bottom,black_0%,black_30%,transparent_92%)] dark:opacity-72 dark:mix-blend-screen"
+      client:visible
+    />
+    <div class="relative z-10 mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24">
+      <div class="mb-8 flex items-center gap-6">
+        <img
+          src="/images/brand/profile-picture.jpg"
+          alt="Patrick Morgan"
+          class="h-20 w-20 rounded-full object-cover"
+          data-hero-photo
           style="opacity: 0;"
         />
+        <div>
+          <p class="mb-1 font-mono text-sm text-muted-foreground" data-hero-label style="opacity: 0;">Software Designer</p>
+          <PixelWaveText
+            text="Patrick Morgan"
+            as="h1"
+            wave="hero"
+            class="text-3xl font-medium tracking-tight sm:text-5xl"
+            style="opacity: 0;"
+          />
+        </div>
       </div>
-    </div>
-    <p class="mb-6 max-w-2xl text-md text-muted-foreground" data-hero-desc style="opacity: 0;">
-      Designing AI cybersecurity tools at
-      <a href="https://sublime.security" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Sublime Security</a> and publishing
-      <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Unknown Arts</a>
-      — a newsletter for creative builders in the age of AI.
-    </p>
-    <div class="flex items-center gap-3 text-muted-foreground" data-hero-icons style="opacity: 0;">
-      <a
-        href={siteConfig.social.newsletter}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="transition-colors hover:text-foreground"
-        aria-label="Substack"
-      >
-        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.6 8.242H1.46V5.406H20.6v2.836zM1.46 10.812V24l9.6-5.55 9.54 5.55V10.812H1.46zM20.6 0H1.46v2.836H20.6V0z"/></svg>
-      </a>
-      <a
-        href={siteConfig.social.linkedin}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="transition-colors hover:text-foreground"
-        aria-label="LinkedIn"
-      >
-        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
-      </a>
-      <a
-        href={siteConfig.social.x}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="transition-colors hover:text-foreground"
-        aria-label="X"
-      >
-        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-      </a>
-      <a
-        href={siteConfig.social.github}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="transition-colors hover:text-foreground"
-        aria-label="GitHub"
-      >
-        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
-      </a>
+      <p class="mb-6 max-w-2xl text-md text-muted-foreground" data-hero-desc style="opacity: 0;">
+        Designing AI cybersecurity tools at
+        <a href="https://sublime.security" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Sublime Security</a> and publishing
+        <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Unknown Arts</a>
+        — a newsletter for creative builders in the age of AI.
+      </p>
+      <div class="flex items-center gap-3 text-muted-foreground" data-hero-icons style="opacity: 0;">
+        <a
+          href={siteConfig.social.newsletter}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="transition-colors hover:text-foreground"
+          aria-label="Substack"
+        >
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.6 8.242H1.46V5.406H20.6v2.836zM1.46 10.812V24l9.6-5.55 9.54 5.55V10.812H1.46zM20.6 0H1.46v2.836H20.6V0z"/></svg>
+        </a>
+        <a
+          href={siteConfig.social.linkedin}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="transition-colors hover:text-foreground"
+          aria-label="LinkedIn"
+        >
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+        </a>
+        <a
+          href={siteConfig.social.x}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="transition-colors hover:text-foreground"
+          aria-label="X"
+        >
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+        </a>
+        <a
+          href={siteConfig.social.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="transition-colors hover:text-foreground"
+          aria-label="GitHub"
+        >
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+        </a>
+      </div>
     </div>
   </section>
 
@@ -189,13 +230,41 @@ const impactStatements: Record<string, string> = {
     <h2 class="mb-8 font-mono text-xs uppercase tracking-widest text-muted-foreground">
       Writing
     </h2>
-    <div class="group mb-10 overflow-hidden rounded-lg border border-border transition-all duration-300 hover:shadow-lg hover:shadow-black/5 dark:hover:shadow-black/20">
-      <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="block overflow-hidden">
-        <img
-          src="/images/unknown-arts/banner.webp"
-          alt="Unknown Arts newsletter"
-          class="aspect-video w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
-        />
+    <div class="group mb-10 overflow-hidden rounded-lg border border-border transition-all duration-300 hover:shadow-lg hover:shadow-black/5 dark:hover:shadow-black/20" data-generative-pattern-trigger>
+      <a
+        href={siteConfig.social.newsletter}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="block overflow-hidden"
+        aria-label="Unknown Arts newsletter"
+      >
+        <div class="relative aspect-video w-full overflow-hidden bg-card transition-transform duration-300 group-hover:scale-[1.01]">
+          <GenerativePatternSurface
+            name="unknown-arts-newsletter"
+            config={newsletterPattern}
+            lightConfig={newsletterLightPattern}
+            duration={2800}
+            interactive
+            className="absolute inset-0 opacity-85 transition-opacity duration-300 group-hover:opacity-100"
+            client:visible
+          />
+          <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_72%_34%,transparent_0%,transparent_28%,var(--background)_82%)] opacity-35 dark:opacity-50"></div>
+          <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-[#171716]/90 via-[#171716]/10 to-transparent opacity-0 dark:opacity-100"></div>
+          <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-background/80 via-background/5 to-transparent dark:hidden"></div>
+          <div class="pointer-events-none absolute bottom-5 left-5 right-5 flex items-end justify-between gap-6">
+            <div>
+              <p class="mb-2 font-mono text-[10px] uppercase tracking-widest text-foreground/55 dark:text-[#ede9e3]/55">
+                Unknown Arts
+              </p>
+              <p class="max-w-sm text-2xl font-medium leading-tight tracking-tight text-foreground dark:text-[#ede9e3] sm:text-4xl">
+                Creative builders in the age of AI
+              </p>
+            </div>
+            <p class="hidden font-mono text-[10px] uppercase tracking-widest text-foreground/35 dark:text-[#ede9e3]/35 sm:block">
+              Seed 88
+            </p>
+          </div>
+        </div>
       </a>
       <div class="p-5 sm:p-6">
         <div class="mb-4 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-8">

--- a/src/pages/lab/editorial-art.astro
+++ b/src/pages/lab/editorial-art.astro
@@ -13,5 +13,5 @@ const entry = (await getCollection("lab")).find((item) => item.data.slug === "ed
   noindex
 >
   <Header />
-  <EditorialArtTool client:only="react" />
+  <EditorialArtTool client:load />
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -233,3 +233,31 @@
     linear-gradient(oklch(0.16 0.01 60 / 0.7), oklch(0.16 0.01 60 / 0.7)),
     url('/images/textures/debut_dark.png');
 }
+
+/* Subtle writing-list signal, inspired by the editorial generator language */
+[data-article-item] {
+  position: relative;
+  overflow: hidden;
+}
+[data-article-item]::before {
+  content: '';
+  position: absolute;
+  inset-block: 0.75rem;
+  left: 0;
+  width: 2px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    oklch(0.72 0.10 75 / 0.55),
+    transparent
+  );
+  opacity: 0;
+  transform: translateY(0.5rem);
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+[data-article-item]:hover::before,
+[data-article-item]:focus-visible::before {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary

- Adds a shared motion model for editorial art canvases with static, reveal, and ambient modes
- Adds native ambient animation support for dot-grid and isoline generators
- Exposes motion controls in the editorial art lab editor, including re-click replay for Reveal mode
- Updates the homepage Unknown Arts module with an ambient generator visual and Unknown Arts mark
- Fixes the editorial art lab route so it server-renders and hydrates with `client:load` instead of depending on a blank `client:only` island

## Verification

- `pnpm build` passes

## Tracking

Refs #48