### PR TITLE
Add colophon page, local time widget, and footer dot grid

### DIFF
--- a/.claude/plans/colophon-local-time-footer.md
+++ b/.claude/plans/colophon-local-time-footer.md
@@ -1,0 +1,35 @@
+# Colophon, Local Time, and Footer Dot Grid
+
+## Context
+
+Issue #30 called for a `/blueprints` colophon page documenting the site's stack and tooling for curious peers. This closes that issue under the name `/colophon` (more conventional). The work expanded into two related affordances — a live local time widget in the footer and a dot grid replacing the flow-field — all of which share the "made with care" narrative.
+
+## Approach
+
+Three distinct additions shipped together since they all touch the footer and share a design rationale:
+
+1. **`/colophon` page** — structured as a `<dl>` with mono labels and prose descriptions, three sections (Stack, AI Agents, Infrastructure), all tool names linked to their homepages.
+2. **`LocalTime.tsx`** — a minimal React component showing `Los Angeles, CA · HH:MM AM/PM` using the `America/Los_Angeles` timezone, updating every 60 seconds via `setInterval`.
+3. **Footer dot grid** — replaced the `flow-field` generative pattern with `dot-grid` (spacing 16, dotSize 58, muted/bronze) for a subtler, pixel-metaphor-consistent texture.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/pages/colophon.astro` | New page at `/colophon` |
+| `src/components/LocalTime.tsx` | New React component for live local time |
+| `src/components/layout/Footer.astro` | Added LocalTime + Colophon + Style Guide links; swapped flow-field → dot-grid; added LocalTime import |
+
+## Steps
+
+1. Build `LocalTime.tsx` with `useEffect` / `setInterval` pattern
+2. Create `colophon.astro` with three section groups and linked `<dt>` labels
+3. Update `Footer.astro` bottom bar: left side `© · Colophon · Style Guide`, right side `<LocalTime />`
+4. Swap footer generative pattern from `flow-field` to `dot-grid` with tuned opacity per mode
+
+## Verification
+
+- `/colophon` renders with three sections and all labels linked externally
+- Footer bottom bar shows live time in Geist Mono, LA timezone
+- Dot grid visible in both dark (muted, opacity 30) and light (bronze, opacity 62) modes with gradient mask fade
+- All existing footer links and layout unaffected

--- a/src/components/LocalTime.tsx
+++ b/src/components/LocalTime.tsx
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+
+export function LocalTime() {
+  const [time, setTime] = useState("");
+
+  useEffect(() => {
+    const update = () => {
+      setTime(
+        new Date().toLocaleTimeString("en-US", {
+          timeZone: "America/Los_Angeles",
+          hour: "numeric",
+          minute: "2-digit",
+          hour12: true,
+        })
+      );
+    };
+    update();
+    const id = setInterval(update, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!time) return null;
+
+  return (
+    <span className="font-mono text-xs text-muted-foreground tabular-nums">
+      Los Angeles, CA&nbsp;&middot;&nbsp;{time}
+    </span>
+  );
+}

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,24 +1,22 @@
 ---
 import { siteConfig } from "@/data/site-config";
 import { GenerativePatternSurface } from "@/lab/editorial-art/GenerativePatternSurface";
+import { LocalTime } from "@/components/LocalTime";
 
 const footerPattern = {
-  type: "flow-field",
-  seed: 614,
-  density: 170,
-  steps: 80,
-  scale: 420,
-  curl: -22,
-  strokeWidth: 0.9,
-  opacity: 52,
-  color: "copper",
+  type: "dot-grid",
+  seed: 247,
+  spacing: 16,
+  scale: 340,
+  dotSize: 58,
+  opacity: 30,
+  color: "muted",
 } as const;
 
 const footerLightPattern = {
   ...footerPattern,
-  opacity: 42,
+  opacity: 62,
   color: "bronze",
-  strokeWidth: 1.2,
 } as const;
 ---
 
@@ -78,13 +76,14 @@ const footerLightPattern = {
       </div>
     </div>
     <div class="flex items-center justify-between text-xs text-muted-foreground">
-      <p>&copy; {new Date().getFullYear()} Patrick Morgan</p>
-      <a
-        href="/style-guide"
-        class="px-2 py-1 text-lg text-muted-foreground/40 transition-colors hover:text-foreground"
-      >
-        ✦
-      </a>
+      <div class="flex items-center gap-3">
+        <p>&copy; {new Date().getFullYear()} Patrick Morgan</p>
+        <span class="text-muted-foreground/30">&middot;</span>
+        <a href="/colophon" class="transition-colors hover:text-accent">Colophon</a>
+        <span class="text-muted-foreground/30">&middot;</span>
+        <a href="/style-guide" class="transition-colors hover:text-accent">Style Guide</a>
+      </div>
+      <LocalTime client:load />
     </div>
   </div>
 </footer>

--- a/src/pages/colophon.astro
+++ b/src/pages/colophon.astro
@@ -1,0 +1,105 @@
+---
+import PageLayout from "@/layouts/PageLayout.astro";
+---
+
+<PageLayout
+  title="Colophon — Patrick Morgan"
+  description="The tools, stack, and workflow behind this site."
+>
+  <section class="mx-auto max-w-3xl px-6 pt-12 pb-16 sm:pt-24">
+    <h1 class="mb-3 text-4xl font-medium tracking-tight sm:text-5xl">Colophon</h1>
+    <p class="mb-16 text-base leading-relaxed text-muted-foreground">
+      What this site is made of and how it gets built. The full story is in{" "}
+      <a
+        href="/writing/how-i-rebuilt-my-portfolio-with-claude-code"
+        class="underline underline-offset-2 transition-colors hover:text-accent"
+      >
+        How I Rebuilt My Portfolio With Claude Code
+      </a>.
+    </p>
+
+    <div class="space-y-12">
+      <div>
+        <p class="mb-6 font-mono text-xs uppercase tracking-widest text-muted-foreground">Stack</p>
+        <dl class="space-y-5">
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://astro.build/" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">Astro v5</a>
+            </dt>
+            <dd class="leading-relaxed">Framework. Ships zero JS by default; content collections enforce schema-validated frontmatter at build time.</dd>
+          </div>
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://tailwindcss.com/" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">Tailwind CSS v4</a>
+            </dt>
+            <dd class="leading-relaxed">Styling. CSS custom properties for theming; OKLCH color tokens for perceptually-uniform light and dark palettes.</dd>
+          </div>
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://ui.shadcn.com/" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">shadcn/ui</a>
+            </dt>
+            <dd class="leading-relaxed">Component library. Base-nova style, built on Radix UI primitives. Themed to match the site's warm, minimal aesthetic.</dd>
+          </div>
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://react.dev/" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">React</a>
+            </dt>
+            <dd class="leading-relaxed">Used only where interactivity requires it — the theme toggle, the generative art surfaces, and the local time widget in the footer.</dd>
+          </div>
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://vercel.com/font" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">Geist</a>
+            </dt>
+            <dd class="leading-relaxed">
+              <a href="https://vercel.com/font" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">Sans</a> for body,{" "}
+              <a href="https://vercel.com/font?type=mono" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">Mono</a> for labels and code,{" "}
+              <a href="https://vercel.com/font?type=pixel" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">Pixel</a> for the hero animation. All from Vercel.
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="border-t border-border pt-12">
+        <p class="mb-6 font-mono text-xs uppercase tracking-widest text-muted-foreground">AI Agents</p>
+        <dl class="space-y-5">
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://claude.ai/code" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">Claude Code</a>
+            </dt>
+            <dd class="leading-relaxed">AI coding agent for interactive sessions — designing and building features collaboratively in the terminal.</dd>
+          </div>
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://openai.com/codex" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">OpenAI Codex</a>
+            </dt>
+            <dd class="leading-relaxed">AI coding agent for autonomous background tasks — running longer agentic loops without occupying a terminal session.</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="border-t border-border pt-12">
+        <p class="mb-6 font-mono text-xs uppercase tracking-widest text-muted-foreground">Infrastructure</p>
+        <dl class="space-y-5">
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://pages.github.com/" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">GitHub Pages</a>
+            </dt>
+            <dd class="leading-relaxed">Static hosting. Free, native to where the code lives.</dd>
+          </div>
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://github.com/features/actions" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">GitHub Actions</a>
+            </dt>
+            <dd class="leading-relaxed">Automated deployment on push to <code class="font-mono text-xs">main</code>.</dd>
+          </div>
+          <div class="grid grid-cols-[10rem_1fr] gap-4 text-sm sm:grid-cols-[12rem_1fr]">
+            <dt class="font-mono text-xs text-muted-foreground pt-0.5">
+              <a href="https://github.com/features/issues" target="_blank" rel="noopener noreferrer" class="transition-colors hover:text-accent">GitHub Issues</a>
+            </dt>
+            <dd class="leading-relaxed">Task tracking. Every enhancement starts as an issue, gets a plan, ships on a feature branch, and merges via PR.</dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  </section>
+</PageLayout>


### PR DESCRIPTION
## Summary

- **`/colophon`** — new page documenting the site's stack, AI agents, and infrastructure. Three sections (Stack, AI Agents, Infrastructure) with linked tool names and brief rationale per entry. References the "How I Rebuilt My Portfolio" article.
- **`LocalTime` component** — live Los Angeles time in the footer, Geist Mono, updates every minute via `setInterval`.
- **Footer bottom bar** — surfaces Colophon and Style Guide as plain text links alongside the time widget; copyright on the left, time on the right.
- **Footer dot grid** — replaces the flow-field generative pattern with a subtle `dot-grid` (spacing 16, muted/bronze) to reinforce the pixel metaphor developing across the site.

## Plan

[`.claude/plans/colophon-local-time-footer.md`](https://github.com/itspatmorgan/itspatmorgan.github.io/blob/colophon-local-time-footer/.claude/plans/colophon-local-time-footer.md)

## Test plan

- [ ] `/colophon` loads with three sections; all tool names link to external homepages
- [ ] Footer time shows correct LA time and updates on the minute
- [ ] Colophon and Style Guide links work from footer
- [ ] Dot grid visible in both dark and light mode (with gradient fade from top)
- [ ] No regressions in footer layout at mobile and desktop widths

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)