### PR TITLE
Small polish fixes bundle

### DIFF
--- a/src/components/LocalTime.tsx
+++ b/src/components/LocalTime.tsx
@@ -14,9 +14,22 @@ export function LocalTime() {
         })
       );
     };
+
     update();
-    const id = setInterval(update, 60_000);
-    return () => clearInterval(id);
+
+    // Align subsequent ticks to the top of each minute
+    const now = new Date();
+    const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+    let intervalId: ReturnType<typeof setInterval>;
+    const timeoutId = setTimeout(() => {
+      update();
+      intervalId = setInterval(update, 60_000);
+    }, msUntilNextMinute);
+
+    return () => {
+      clearTimeout(timeoutId);
+      clearInterval(intervalId);
+    };
   }, []);
 
   if (!time) return null;

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -75,7 +75,7 @@ const footerLightPattern = {
         </a>
       </div>
     </div>
-    <div class="flex items-center justify-between text-xs text-muted-foreground">
+    <div class="flex flex-col gap-3 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
       <div class="flex items-center gap-3">
         <p>&copy; {new Date().getFullYear()} Patrick Morgan</p>
         <span class="text-muted-foreground/30">&middot;</span>

--- a/src/content/projects/characters.mdx
+++ b/src/content/projects/characters.mdx
@@ -6,7 +6,7 @@ skills: ["Product Design", "Systems Design", "Prototyping"]
 thumbnail: "/images/projects/characters/thumbnail-characters-light.png"
 thumbnailDark: "/images/projects/characters/thumbnail-characters-dark.png"
 sortOrder: 4
-draft: false
+draft: true
 ---
 
 import { YouTube } from 'astro-embed';

--- a/src/content/projects/gpts.mdx
+++ b/src/content/projects/gpts.mdx
@@ -6,7 +6,7 @@ skills: ["Prompt Design", "Content Strategy", "Prototyping"]
 thumbnail: "/images/projects/gpts/thumbnail-gpt-guides-light.png"
 thumbnailDark: "/images/projects/gpts/thumbnail-gpt-guides-dark.png"
 sortOrder: 5
-draft: false
+draft: true
 ---
 
 import { YouTube } from 'astro-embed';

--- a/src/data/commendations.ts
+++ b/src/data/commendations.ts
@@ -110,10 +110,4 @@ export const commendations: Commendation[] = [
     quote:
       "SUPER highly recommend subscribing to @itspatmorgan's newsletter. It's always filled with really insightful nuggets of wisdom about design, entrepreneurship, business and more!",
   },
-  {
-    name: "Ehsan Nour",
-    role: "Product Design @ Eraser",
-    image: "/images/profiles/ehsan.avif",
-    quote: "Patrick turned it up to 11 recently.",
-  },
 ];

--- a/src/lab/editorial-art/index.tsx
+++ b/src/lab/editorial-art/index.tsx
@@ -518,6 +518,7 @@ export default function EditorialArtTool() {
   const panelContentRef = useRef<HTMLDivElement>(null);
   const panelScrollIdleRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const [scale, setScale]             = useState(0.6);
+  const [canvasReady, setCanvasReady] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [exportingStill, setExportingStill] = useState(false);
   const [motionReplayKey, setMotionReplayKey] = useState(0);
@@ -533,6 +534,7 @@ export default function EditorialArtTool() {
       setScale(Math.min((width - 48) / CANVAS_W, (height - 48) / CANVAS_H, 1));
     };
     update();
+    setCanvasReady(true);
     const ro = new ResizeObserver(update);
     if (containerRef.current) ro.observe(containerRef.current);
     return () => ro.disconnect();
@@ -991,6 +993,8 @@ export default function EditorialArtTool() {
             flexShrink: 0,
             boxShadow: '0 2px 24px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.06)',
             borderRadius: 2,
+            opacity: canvasReady ? 1 : 0,
+            transition: 'opacity 0.4s ease-out',
           }}
         >
           <ArtCanvas

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,14 +27,6 @@ const writingPosts = (await getCollection("writing", ({ data }) => !data.draft))
 const professionalProjects = allProjects
   .filter((p) => p.data.type === "professional")
   .sort((a, b) => a.data.sortOrder - b.data.sortOrder);
-const experimentProjects = allProjects
-  .filter((p) => p.data.type === "experiment")
-  .sort((a, b) => a.data.sortOrder - b.data.sortOrder);
-
-const experimentIcons: Record<string, string> = {
-  "characters": "/images/logos/square-claude.svg",
-  "gpts": "/images/logos/square-chatgpt.svg",
-};
 
 const impactStatements: Record<string, string> = {
   "query-language": "Reduced new users' time to build a custom query from 21 days to 1.",
@@ -161,40 +153,11 @@ const newsletterMotion = {
     </div>
   </section>
 
-  {/* AI Experiments */}
-  <section class="mx-auto max-w-3xl border-t border-border px-6 py-16" data-section-entrance style="opacity: 0;">
-    <h2 class="mb-8 font-mono text-xs uppercase tracking-widest text-muted-foreground">
-      AI Experiments
-    </h2>
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      {experimentProjects.map((project, i) => (
-        <div data-project-card-item style="opacity: 0;">
-          <ProjectCard
-            title={project.data.title}
-            description={project.data.description}
-            skills={project.data.skills}
-            thumbnail={project.data.thumbnail}
-            thumbnailDark={project.data.thumbnailDark}
-            slug={project.id}
-            index={i}
-            variant="compact"
-            icon={experimentIcons[project.id]}
-          />
-        </div>
-      ))}
-    </div>
-  </section>
-
   {/* Lab */}
   <section class="mx-auto max-w-3xl border-t border-border px-6 py-16" data-section-entrance style="opacity: 0;">
-    <div class="mb-8 flex items-center justify-between gap-6">
-      <h2 class="font-mono text-xs uppercase tracking-widest text-muted-foreground">
-        Lab
-      </h2>
-      <a href="/lab" class="text-sm text-muted-foreground transition-colors hover:text-accent">
-        View all &rarr;
-      </a>
-    </div>
+    <h2 class="mb-8 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+      Lab
+    </h2>
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       {labEntries.slice(0, 2).map((entry) => (
         <div data-project-card-item style="opacity: 0;">
@@ -207,6 +170,9 @@ const newsletterMotion = {
           />
         </div>
       ))}
+    </div>
+    <div class="mt-8 flex items-center gap-6 text-sm">
+      <a href="/lab" class="transition-colors hover:text-accent">View all &rarr;</a>
     </div>
   </section>
 
@@ -291,7 +257,7 @@ const newsletterMotion = {
       ))}
     </div>
     <div class="mt-8 flex items-center gap-6 text-sm">
-      <a href="/writing" class="transition-colors hover:text-accent">View all articles &rarr;</a>
+      <a href="/writing" class="transition-colors hover:text-accent">View all &rarr;</a>
     </div>
   </section>
 

--- a/src/pages/lab/editorial-art.astro
+++ b/src/pages/lab/editorial-art.astro
@@ -13,5 +13,22 @@ const entry = (await getCollection("lab")).find((item) => item.data.slug === "ed
   noindex
 >
   <Header />
-  <EditorialArtTool client:load />
+  <div class="lab-tool-fade">
+    <EditorialArtTool client:load />
+  </div>
 </BaseLayout>
+
+<style>
+  .lab-tool-fade {
+    animation: lab-tool-in 0.5s ease-out both;
+  }
+
+  @keyframes lab-tool-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .lab-tool-fade { animation: none; }
+  }
+</style>

--- a/src/pages/lab/pixel-mark.astro
+++ b/src/pages/lab/pixel-mark.astro
@@ -14,7 +14,7 @@ const { Content } = await render(entry);
   description={entry.data.description}
   noindex
 >
-  <section class="mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24">
+  <section class="mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24" data-lab-hero style="opacity: 0">
     <a
       href="/lab"
       class="mb-8 inline-flex items-center gap-1 font-mono text-sm text-muted-foreground transition-colors hover:text-foreground"
@@ -32,7 +32,7 @@ const { Content } = await render(entry);
   </section>
 
   <!-- Hero display -->
-  <section>
+  <section data-lab-content style="opacity: 0">
     <div class="mx-auto max-w-3xl px-6 pb-16">
       <div class="flex min-h-48 items-center justify-center rounded-lg border border-border bg-card">
         <svg
@@ -77,6 +77,21 @@ const { Content } = await render(entry);
     </div>
   </section>
 </PageLayout>
+
+<script>
+  import { animate } from "motion";
+
+  function init() {
+    const hero = document.querySelector<HTMLElement>("[data-lab-hero]");
+    const content = document.querySelector<HTMLElement>("[data-lab-content]");
+    const spring = { type: "spring" as const, stiffness: 160, damping: 20, mass: 0.8 };
+    if (hero) animate(hero, { opacity: [0, 1], y: [16, 0] }, { ...spring });
+    if (content) animate(content, { opacity: [0, 1] }, { duration: 0.4, easing: "ease-out", delay: 0.2 });
+  }
+
+  init();
+  document.addEventListener("astro:after-swap", init);
+</script>
 
 <style>
   .hero-pixel { fill: var(--color-background); }

--- a/src/pages/lab/pixel-wave.astro
+++ b/src/pages/lab/pixel-wave.astro
@@ -14,7 +14,7 @@ const { Content } = await render(entry);
   description={entry.data.description}
   noindex
 >
-  <section class="mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24">
+  <section class="mx-auto max-w-3xl px-6 pt-12 pb-12 sm:pt-24" data-lab-hero style="opacity: 0">
     <a
       href="/lab"
       class="mb-8 inline-flex items-center gap-1 font-mono text-sm text-muted-foreground transition-colors hover:text-foreground"
@@ -29,7 +29,7 @@ const { Content } = await render(entry);
     <p class="max-w-xl text-lg text-muted-foreground">{entry.data.description}</p>
   </section>
 
-  <section class="mx-auto max-w-3xl border-t border-border px-6 py-16" data-pixel-wave-demo>
+  <section class="mx-auto max-w-3xl border-t border-border px-6 py-16" data-pixel-wave-demo data-lab-content style="opacity: 0">
     <div class="grid gap-8">
       <div class="relative flex min-h-[22rem] items-center justify-center rounded-lg border border-border bg-card px-6 py-16 text-center texture-bg">
         <PixelWaveText
@@ -60,9 +60,8 @@ const { Content } = await render(entry);
 </PageLayout>
 
 <script>
+  import { animate } from "motion";
   import { pixelWave, enablePixelHover } from "@/scripts/pixel-wave";
-
-  const SESSION_KEY = "pixelWaveDemoSeen";
 
   function resetWave(container: HTMLElement) {
     container.querySelectorAll<HTMLElement>("[data-pw-char]").forEach((wrapper) => {
@@ -99,17 +98,20 @@ const { Content } = await render(entry);
       }, delay + 5000);
     };
 
-    if (sessionStorage.getItem(SESSION_KEY)) {
-      resolveWave(container);
-      window.setTimeout(() => enablePixelHover(container), 100);
-    } else {
-      sessionStorage.setItem(SESSION_KEY, "1");
-      play(250);
-    }
+    play(250);
 
     if (replay) replay.onclick = () => play(0);
   }
 
+  function initLabAnimation() {
+    const hero = document.querySelector<HTMLElement>("[data-lab-hero]");
+    const content = document.querySelector<HTMLElement>("[data-lab-content]");
+    const spring = { type: "spring" as const, stiffness: 160, damping: 20, mass: 0.8 };
+    if (hero) animate(hero, { opacity: [0, 1], y: [16, 0] }, { ...spring });
+    if (content) animate(content, { opacity: [0, 1] }, { duration: 0.4, easing: "ease-out", delay: 0.2 });
+  }
+
+  initLabAnimation();
   initPixelWaveDemo();
-  document.addEventListener("astro:after-swap", initPixelWaveDemo);
+  document.addEventListener("astro:after-swap", () => { initLabAnimation(); initPixelWaveDemo(); });
 </script>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -68,7 +68,6 @@ const arcNodes = ["Strategist", "Developer", "Designer", "Writer", "Builder"];
     <p class="mb-10 font-mono text-xs uppercase tracking-widest text-muted-foreground">Writing</p>
     <div class="mb-5 font-mono text-xs text-muted-foreground">2022–Now</div>
     <img src="/images/logos/career-unknownarts.svg" alt="Unknown Arts" class="logo-adaptive mb-4 h-5" />
-    <p class="mb-5 text-base font-semibold leading-snug">Writer</p>
     <ul class="flex flex-col gap-5">
       <li class="text-sm leading-relaxed text-muted-foreground">Created a newsletter growing to 7,500+ subscribers and ~40% open rate.</li>
       <li class="text-sm leading-relaxed text-muted-foreground">Featured in top industry publications, reaching a global audience across 128 countries.</li>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -40,7 +40,7 @@ const filterThemes = [
       >
         <button
           type="button"
-          class="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-foreground hover:text-foreground aria-pressed:bg-muted aria-pressed:text-foreground"
+          class="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground transition-colors duration-200 hover:border-foreground hover:text-foreground aria-pressed:bg-muted aria-pressed:text-foreground"
           data-theme-filter="all"
           aria-pressed="true"
         >
@@ -49,7 +49,7 @@ const filterThemes = [
         {filterThemes.map((theme) => (
           <button
             type="button"
-            class="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-foreground hover:text-foreground aria-pressed:bg-muted aria-pressed:text-foreground"
+            class="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground transition-colors duration-200 hover:border-foreground hover:text-foreground aria-pressed:bg-muted aria-pressed:text-foreground"
             data-theme-filter={theme}
             aria-pressed="false"
           >


### PR DESCRIPTION
Closes #57

## Summary
- Footer mobile layout fix, writing filter transitions, resume cleanup
- Lab page entrance animations; pixel wave always plays on detail page; editorial art canvas fade
- AI Experiments archived; kind words card balance; local time clock accuracy; "View all" link consistency

## Test plan
- [ ] Footer bottom bar stacks on mobile (≤375px)
- [ ] Writing filter buttons animate on hover
- [ ] Resume writing section has no "Writer" label
- [ ] Lab detail pages (pixel-mark, pixel-wave, editorial-art) animate in on load
- [ ] Pixel Wave demo plays every visit, not just first
- [ ] Editorial Art canvas fades in smoothly
- [ ] Home page has no AI Experiments section; characters/gpts return 404
- [ ] Kind Words section has no orphaned card at column bottom
- [ ] Footer clock matches system time to within 1 second of each minute turn
- [ ] Lab and Writing both show "View all →" below their content

🤖 Generated with [Claude Code](https://claude.com/claude-code)