### PR TITLE
Fix pattern engine URL tone overrides

### DIFF
--- a/src/lab/editorial-art/index.tsx
+++ b/src/lab/editorial-art/index.tsx
@@ -239,13 +239,15 @@ function initialStateFromUrl(): AppState {
   if (!window.location.search) return state;
   const generator = parseGenerator(params, state.generator);
   const autoTone = params.get('tone') === 'auto' ? currentColorModeTone() : null;
+  const bgColor = bgColorFromParam(params.get('bg'), autoTone?.bgColor ?? state.bgColor);
+  const generatorColor = params.get('color') === null && autoTone ? { color: autoTone.color } : {};
 
   return {
     ...state,
-    bgColor: autoTone?.bgColor ?? bgColorFromParam(params.get('bg'), state.bgColor),
+    bgColor,
     generator: {
       ...generator,
-      ...(autoTone ? { color: autoTone.color } : {}),
+      ...generatorColor,
     } as GeneratorConfig,
     texture: numberParam(params, 'texture', state.texture),
     grain: numberParam(params, 'grain', state.grain),


### PR DESCRIPTION
## Summary
- Preserve explicit Pattern Engine URL background and color params when tone=auto is present
- Keep tone=auto as a fallback for missing bg/color values

## Verification
- pnpm build
- Browser verified exact shared URL resolves to dark/copper Isoline settings