### PR TITLE
Clean up Pattern Engine URL params

### DIFF
--- a/src/lab/editorial-art/index.tsx
+++ b/src/lab/editorial-art/index.tsx
@@ -10,7 +10,6 @@ import {
   resolveLayerColor,
   isColorDark,
   staticMotion,
-  type ThemeId,
   type LayerColor,
   type Composition,
   type GeneratorConfig,
@@ -28,7 +27,6 @@ import {
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 interface AppState {
-  themeId: ThemeId;
   bgColor: string;
   generator: GeneratorConfig;
   texture: number;
@@ -105,10 +103,9 @@ function rf(min: number, max: number, dec = 1): number {
   return parseFloat((Math.random() * (max - min) + min).toFixed(dec));
 }
 
-function defaultState(themeId: ThemeId): AppState {
-  const t = themes[themeId];
+function defaultState(): AppState {
+  const t = themes.ai;
   return {
-    themeId,
     bgColor: t.defaultBgColor,
     generator: { ...t.defaultGenerator },
     texture: t.defaultTexture,
@@ -124,28 +121,12 @@ function defaultState(themeId: ThemeId): AppState {
   };
 }
 
-function themeIdFromParam(value: string | null): ThemeId {
-  if (!value) return 'ai';
-  const normalized = value.toLowerCase().replace(/\s+/g, '-');
-  const matched = Object.values(themes).find((theme) =>
-    theme.id === normalized || theme.label.toLowerCase().replace(/\s+/g, '-') === normalized
-  );
-  return matched?.id ?? 'ai';
-}
-
 function bgColorFromParam(value: string | null, fallback: string): string {
   if (value === 'paper') return brand.paper;
   if (value === 'off-white') return brand.offWhite;
   if (value === 'warm-dark-gray' || value === 'dark') return brand.warmDarkGray;
   if (value && /^#[0-9a-f]{6}$/i.test(value)) return value;
   return fallback;
-}
-
-function currentColorModeTone(): { bgColor: string; color: LayerColor } {
-  const dark = document.documentElement.classList.contains('dark');
-  return dark
-    ? { bgColor: brand.warmDarkGray, color: 'copper' }
-    : { bgColor: brand.paper, color: 'bronze' };
 }
 
 function numberParam(params: URLSearchParams, key: string, fallback: number): number {
@@ -232,23 +213,16 @@ function parseGenerator(params: URLSearchParams, fallback: GeneratorConfig): Gen
 }
 
 function initialStateFromUrl(): AppState {
-  if (typeof window === 'undefined') return defaultState('ai');
+  if (typeof window === 'undefined') return defaultState();
   const params = new URLSearchParams(window.location.search);
-  const themeId = themeIdFromParam(params.get('theme'));
-  const state = defaultState(themeId);
+  const state = defaultState();
   if (!window.location.search) return state;
   const generator = parseGenerator(params, state.generator);
-  const autoTone = params.get('tone') === 'auto' ? currentColorModeTone() : null;
-  const bgColor = bgColorFromParam(params.get('bg'), autoTone?.bgColor ?? state.bgColor);
-  const generatorColor = params.get('color') === null && autoTone ? { color: autoTone.color } : {};
 
   return {
     ...state,
-    bgColor,
-    generator: {
-      ...generator,
-      ...generatorColor,
-    } as GeneratorConfig,
+    bgColor: bgColorFromParam(params.get('bg'), state.bgColor),
+    generator,
     texture: numberParam(params, 'texture', state.texture),
     grain: numberParam(params, 'grain', state.grain),
     motion: parseMotion(params, state.motion),
@@ -544,14 +518,6 @@ export default function EditorialArtTool() {
 
   const set = useCallback((patch: Partial<AppState>) => {
     setState((prev) => {
-      if (patch.themeId && patch.themeId !== prev.themeId) {
-        return {
-          ...defaultState(patch.themeId),
-          title: prev.title, slug: prev.slug,
-          slugEdited: prev.slugEdited, showText: prev.showText,
-          motion: prev.motion,
-        };
-      }
       return { ...prev, ...patch };
     });
   }, []);

--- a/src/layouts/WritingLayout.astro
+++ b/src/layouts/WritingLayout.astro
@@ -45,61 +45,59 @@ function visualCaption(visual: Props["visual"]): string | undefined {
   return `${generatorLabel(generator.type)} · seed ${generator.seed}`;
 }
 
-function toolThemeId(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  const map: Record<string, string> = {
-    ai: "ai",
-    design: "design",
-    systems: "systems",
-    "systems thinking": "systems",
-    creative: "creative",
-    "creative practice": "creative",
-    career: "career",
-  };
-  return map[value.toLowerCase()];
-}
-
 function addParam(params: URLSearchParams, key: string, value: unknown): void {
   if (value === undefined || value === null || value === "") return;
   params.set(key, String(value));
 }
 
-function visualToolHref(visual: Props["visual"], articleTheme: string | undefined): string {
+function addParams(params: URLSearchParams, entries: [string, unknown][]): void {
+  for (const [key, value] of entries) addParam(params, key, value);
+}
+
+function visualToolHref(visual: Props["visual"]): string {
   if (!visual) return "/lab/pattern-engine";
   const generator = visual.generator;
   const params = new URLSearchParams();
 
-  addParam(params, "theme", toolThemeId(visual.theme) ?? toolThemeId(articleTheme));
-  addParam(params, "tone", "auto");
-  addParam(params, "bg", visual.background);
-  addParam(params, "generator", generator.type);
-  addParam(params, "seed", generator.seed);
-  addParam(params, "opacity", generator.opacity);
-  addParam(params, "color", generator.color);
-  addParam(params, "texture", visual.texture);
-  addParam(params, "grain", visual.grain);
+  addParams(params, [
+    ["bg", visual.background],
+    ["generator", generator.type],
+    ["seed", generator.seed],
+    ["color", generator.color],
+    ["opacity", generator.opacity],
+    ["texture", visual.texture],
+    ["grain", visual.grain],
+  ]);
 
   if (generator.type === "flow-field") {
-    addParam(params, "density", generator.density);
-    addParam(params, "steps", generator.steps);
-    addParam(params, "scale", generator.scale);
-    addParam(params, "curl", generator.curl);
-    addParam(params, "strokeWidth", generator.strokeWidth);
+    addParams(params, [
+      ["density", generator.density],
+      ["steps", generator.steps],
+      ["scale", generator.scale],
+      ["curl", generator.curl],
+      ["strokeWidth", generator.strokeWidth],
+    ]);
   }
   if (generator.type === "dot-grid") {
-    addParam(params, "spacing", generator.spacing);
-    addParam(params, "scale", generator.scale);
-    addParam(params, "dotSize", generator.dotSize);
+    addParams(params, [
+      ["spacing", generator.spacing],
+      ["scale", generator.scale],
+      ["dotSize", generator.dotSize],
+    ]);
   }
   if (generator.type === "isoline") {
-    addParam(params, "levels", generator.levels);
-    addParam(params, "scale", generator.scale);
-    addParam(params, "strokeWidth", generator.strokeWidth);
+    addParams(params, [
+      ["levels", generator.levels],
+      ["scale", generator.scale],
+      ["strokeWidth", generator.strokeWidth],
+    ]);
   }
   if (generator.type === "voronoi") {
-    addParam(params, "count", generator.count);
-    addParam(params, "jitter", generator.jitter);
-    addParam(params, "strokeWidth", generator.strokeWidth);
+    addParams(params, [
+      ["count", generator.count],
+      ["jitter", generator.jitter],
+      ["strokeWidth", generator.strokeWidth],
+    ]);
   }
 
   const query = params.toString();
@@ -107,7 +105,7 @@ function visualToolHref(visual: Props["visual"], articleTheme: string | undefine
 }
 
 const generatedCaption = visualCaption(visual);
-const generatedToolHref = visualToolHref(visual, theme);
+const generatedToolHref = visualToolHref(visual);
 ---
 
 <PageLayout title={title} description={description} image={image} canonicalUrl={canonicalUrl}>


### PR DESCRIPTION
## Summary
- Remove redundant theme and tone params from generated Pattern Engine links
- Keep generated URLs ordered around explicit render state
- Stop using theme/tone as Pattern Engine parser compatibility paths

## Verification
- pnpm build
- Browser verified clean and old-shaped URLs resolve to the same explicit render state