### PR TITLE
Polish nav labs and homepage hero

### DIFF
--- a/.claude/plans/nav-lab-quick-fixes.md
+++ b/.claude/plans/nav-lab-quick-fixes.md
@@ -1,0 +1,44 @@
+# Nav and Lab Quick Fixes
+
+## Context
+
+The site sidebar is now driven by the pixel mark and should default to the collapsed icon rail for first-time desktop visitors. That makes icon labels more important on hover/focus. The mobile navigation also needs to use less vertical space on iPhone-sized screens, the homepage hero needs to work with the collapsed nav and revised visual rhythm, and the Pixel Mark lab should document the nav switcher interaction now used in production.
+
+## Approach
+
+- Tighten the mobile navigation typography and spacing while preserving the existing overlay structure.
+- Remove the mobile "Elsewhere" label and slightly reduce the social section spacing.
+- Default the desktop sidebar to collapsed only when no saved preference exists.
+- Add a custom, faster sidebar tooltip that works for collapsed icon controls.
+- Update the homepage headline and intro copy so Patrick's name appears even when the sidebar is collapsed.
+- Remove the career arc nodes from the homepage hero and rebalance the mobile/desktop hero spacing.
+- Add a subtle dot-grid texture that anchors the portrait on desktop and becomes a top fade on mobile.
+- Coordinate the desktop hero and first Work-card entrance animation.
+- Remove the Pixel Wave lab's page divider between the intro and demo area.
+- Add a Pixel Mark lab section documenting the sidebar switcher states.
+
+## Files to Modify
+
+- `src/components/layout/MobileNav.astro` — mobile overlay link sizing and social label removal.
+- `src/components/layout/Sidebar.astro` — default collapsed behavior and custom collapsed tooltips.
+- `src/pages/index.astro` — homepage hero copy, dot-grid texture, and Work entrance hooks.
+- `src/scripts/home-animations.ts` — desktop hero-to-Work animation sequencing.
+- `src/pages/lab/pixel-wave.astro` — mobile divider cleanup.
+- `src/pages/lab/pixel-mark.astro` — add nav switcher documentation section.
+- `src/lab/pixel-mark/MarkStates.tsx` — reusable production nav switcher state demo.
+
+## Steps
+
+1. Update mobile nav classes and remove the label.
+2. Adjust sidebar collapse initialization and tooltip behavior.
+3. Update homepage headline and intro copy.
+4. Remove career arc nodes and tune hero spacing/texture.
+5. Coordinate desktop entrance animation across hero and Work preview.
+6. Remove lab dividers and match lab spacing.
+7. Add Pixel Mark nav switcher state docs.
+8. Run `pnpm build`.
+
+## Verification
+
+- `pnpm build`
+- Browser check for the homepage, mobile nav, and Pixel Mark lab if a dev server is needed after build.

--- a/src/components/layout/MobileNav.astro
+++ b/src/components/layout/MobileNav.astro
@@ -42,7 +42,7 @@ const elsewhere = [
         <li data-mobile-nav-item>
           <a
             href={item.href}
-            class="block py-4 text-3xl font-medium text-muted-foreground hover:text-foreground transition-colors border-b border-border/50 last:border-0"
+            class="block border-b border-border/50 py-3 text-[1.65rem] font-medium leading-tight text-muted-foreground transition-colors hover:text-foreground last:border-0"
           >
             {item.label}
           </a>
@@ -52,8 +52,7 @@ const elsewhere = [
   </nav>
 
   {/* Elsewhere */}
-  <div class="px-8 py-8 border-t border-border shrink-0" data-mobile-nav-elsewhere>
-    <p class="mb-4 font-mono text-[10px] uppercase tracking-widest text-muted-foreground/60">Elsewhere</p>
+  <div class="px-8 py-6 border-t border-border shrink-0" data-mobile-nav-elsewhere>
     <ul class="grid grid-cols-2 gap-x-6 gap-y-4">
       {elsewhere.map((item) => (
         <li>

--- a/src/components/layout/Sidebar.astro
+++ b/src/components/layout/Sidebar.astro
@@ -76,6 +76,7 @@ const elsewhere = [
       class="flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-lg"
       aria-label="Toggle sidebar"
       title="Toggle sidebar"
+      data-sidebar-tooltip="Expand navigation"
     >
       <Logo interaction="sidebar-toggle" class="h-8 w-8" />
     </button>
@@ -93,6 +94,7 @@ const elsewhere = [
           <a
             href={item.href}
             title={item.label}
+            data-sidebar-tooltip={item.label}
             class:list={[
               "nav-item flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm transition-colors duration-200",
               isActive(item.href)
@@ -124,6 +126,7 @@ const elsewhere = [
               rel="noopener noreferrer"
               aria-label={item.label}
               title={item.label}
+              data-sidebar-tooltip={item.label}
               class="elsewhere-item flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors duration-200 hover:text-foreground"
             >
               <svg class="shrink-0 h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" set:html={item.icon} />
@@ -136,10 +139,11 @@ const elsewhere = [
         id="elsewhere-rollup-btn"
       class="h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors duration-200 hover:bg-foreground/5 hover:text-foreground"
         type="button"
-        aria-label="Elsewhere links"
+        aria-label="Links"
         aria-expanded="false"
         aria-controls="elsewhere-rollup-panel"
-        title="Elsewhere links"
+        title="Links"
+        data-sidebar-tooltip="Links"
       >
         <Globe2 size={18} strokeWidth={1.75} aria-hidden="true" />
       </button>
@@ -155,6 +159,7 @@ const elsewhere = [
             type="button"
             aria-label="Toggle color theme"
             title="Toggle color theme"
+            data-sidebar-tooltip="Toggle theme"
           >
             <svg class="theme-icon-moon h-[18px] w-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401z"></path>
@@ -177,7 +182,7 @@ const elsewhere = [
   </div>
 
   <div id="elsewhere-rollup-panel" class="fixed bottom-3 left-[4.5rem] invisible w-44 translate-x-[-0.25rem] rounded-lg border border-border bg-background p-1.5 opacity-0 shadow-lg transition-all duration-200" aria-hidden="true" inert>
-    <p class="px-2 pb-1.5 pt-1 font-mono text-[10px] uppercase tracking-widest text-muted-foreground/60">Elsewhere</p>
+    <p class="px-2 pb-1.5 pt-1 font-mono text-[10px] uppercase tracking-widest text-muted-foreground/60">Links</p>
     <ul>
       {elsewhere.map((item) => (
         <li>
@@ -366,6 +371,37 @@ const elsewhere = [
     opacity: 1;
   }
 
+  #sidebar-tooltip {
+    position: fixed;
+    z-index: 80;
+    pointer-events: none;
+    transform: translateY(-50%) translateX(-3px);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--popover);
+    color: var(--popover-foreground);
+    box-shadow: 0 12px 32px color-mix(in oklch, var(--foreground) 14%, transparent);
+    opacity: 0;
+    padding: 6px 9px;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    transition:
+      opacity 90ms ease-out,
+      transform 90ms ease-out;
+  }
+
+  #sidebar-tooltip.is-visible {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+    transition-delay: 80ms;
+  }
+
+  html.dark #sidebar-tooltip {
+    box-shadow: 0 10px 24px oklch(0 0 0 / 38%);
+  }
+
 </style>
 
 <script>
@@ -396,9 +432,11 @@ const elsewhere = [
       rollupBtn?.setAttribute("aria-expanded", String(open));
     }
 
-    const collapsed = localStorage.getItem("sidebar-collapsed") === "true";
+    const savedPreference = localStorage.getItem("sidebar-collapsed");
+    const collapsed = savedPreference === null ? true : savedPreference === "true";
     sidebar.style.transition = "none";
     applyCollapsed(sidebar, collapsed);
+    btn.dataset.sidebarTooltip = collapsed ? "Expand navigation" : "Collapse navigation";
     requestAnimationFrame(() => { sidebar.style.transition = ""; });
 
     if (btn.dataset.sidebarInitialized === "true") return;
@@ -409,6 +447,7 @@ const elsewhere = [
       setRollupOpen(false);
       applyCollapsed(sidebar, isNowCollapsed);
       localStorage.setItem("sidebar-collapsed", String(isNowCollapsed));
+      btn.dataset.sidebarTooltip = isNowCollapsed ? "Expand navigation" : "Collapse navigation";
     });
 
     rollupBtn?.addEventListener("click", (event) => {
@@ -421,6 +460,55 @@ const elsewhere = [
       if (event.key === "Escape") setRollupOpen(false);
     });
 
+  }
+
+  function initSidebarTooltips() {
+    let tooltip = document.getElementById("sidebar-tooltip") as HTMLElement | null;
+    if (!tooltip) {
+      tooltip = document.createElement("div");
+      tooltip.id = "sidebar-tooltip";
+      tooltip.setAttribute("role", "tooltip");
+      tooltip.setAttribute("aria-hidden", "true");
+      document.body.appendChild(tooltip);
+    }
+
+    const targets = document.querySelectorAll<HTMLElement>("#sidebar [data-sidebar-tooltip]");
+
+    function hideTooltip() {
+      if (!tooltip) return;
+      tooltip.classList.remove("is-visible");
+      tooltip.setAttribute("aria-hidden", "true");
+    }
+
+    function showTooltip(target: HTMLElement) {
+      if (!tooltip) return;
+      if (!document.documentElement.classList.contains("sidebar-collapsed")) return;
+
+      const label = target.dataset.sidebarTooltip;
+      if (!label) return;
+
+      const rect = target.getBoundingClientRect();
+      tooltip.textContent = label;
+      tooltip.style.left = `${rect.right + 10}px`;
+      tooltip.style.top = `${rect.top + rect.height / 2}px`;
+      tooltip.classList.add("is-visible");
+      tooltip.setAttribute("aria-hidden", "false");
+    }
+
+    targets.forEach((target) => {
+      if (target.dataset.tooltipInitialized === "true") return;
+      target.dataset.tooltipInitialized = "true";
+      target.addEventListener("pointerenter", () => showTooltip(target));
+      target.addEventListener("pointerleave", hideTooltip);
+      target.addEventListener("focus", () => showTooltip(target));
+      target.addEventListener("blur", hideTooltip);
+    });
+
+    if (document.documentElement.dataset.sidebarTooltipGlobalInitialized !== "true") {
+      document.documentElement.dataset.sidebarTooltipGlobalInitialized = "true";
+      document.addEventListener("scroll", hideTooltip, { passive: true });
+      window.addEventListener("resize", hideTooltip);
+    }
   }
 
   function initSidebarFooterControls() {
@@ -476,7 +564,9 @@ const elsewhere = [
   }
 
   initSidebar();
+  initSidebarTooltips();
   initSidebarFooterControls();
   document.addEventListener("astro:after-swap", initSidebar);
+  document.addEventListener("astro:after-swap", initSidebarTooltips);
   document.addEventListener("astro:after-swap", initSidebarFooterControls);
 </script>

--- a/src/lab/pixel-mark/MarkStates.tsx
+++ b/src/lab/pixel-mark/MarkStates.tsx
@@ -255,6 +255,60 @@ function RollMark({ rolling, configIdx }: { rolling: boolean; configIdx: number 
   );
 }
 
+// ─── Production sidebar switcher ─────────────────────────────────────────────
+
+function NavSwitcherMark({ direction }: { direction: "collapse" | "expand" }) {
+  const [active, setActive] = useState(false);
+  const transformFor = (index: number) => {
+    if (direction === "collapse") {
+      if (index === 0) return "translate(7px, 0)";
+      if (index === 1) return "translate(-7px, 7px)";
+      if (index === 2) return "translate(7px, 7px)";
+      return "none";
+    }
+
+    if (index === 1 || index === 2) return "translate(0, 7px)";
+    return "none";
+  };
+
+  return (
+    <button
+      type="button"
+      className="group flex flex-col items-center gap-5 rounded-lg p-2 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      aria-label={`Preview ${direction} navigation state`}
+      aria-pressed={active}
+      onMouseEnter={() => setActive(true)}
+      onMouseLeave={() => setActive(false)}
+      onFocus={() => setActive(true)}
+      onBlur={() => setActive(false)}
+      onClick={() => setActive(true)}
+    >
+      <div className="rounded-lg p-2">
+        <svg width={48} height={48} viewBox="0 0 28 28" aria-hidden>
+          <rect width="28" height="28" rx={6.2} style={{ fill: "var(--color-secondary)" }} />
+          {BRAILLE_P.map(([cx, cy], i) => (
+            <rect
+              key={i}
+              x={cx - PIXEL_SIZE / 2}
+              y={cy - PIXEL_SIZE / 2}
+              width={PIXEL_SIZE}
+              height={PIXEL_SIZE}
+              rx={PIXEL_RADIUS}
+              className="transition-all duration-300 ease-out group-hover:[transition-timing-function:cubic-bezier(0.16,1,0.3,1)]"
+              style={{
+                fill: "var(--color-secondary-foreground)",
+                transformOrigin: `${cx}px ${cy}px`,
+                transform: active ? transformFor(i) : undefined,
+                opacity: active && i === 3 ? 0 : 1,
+              }}
+            />
+          ))}
+        </svg>
+      </div>
+    </button>
+  );
+}
+
 // ─── Scale strip ─────────────────────────────────────────────────────────────
 
 export function ScaleStrip() {
@@ -361,6 +415,19 @@ export function MarkStates() {
       <StateCard label="Accent"><AccentState /></StateCard>
       <StateCard label="Roll" action={<PlayButton onClick={roll} disabled={rolling} />}>
         <RollMark rolling={rolling} configIdx={configIdx} />
+      </StateCard>
+    </div>
+  );
+}
+
+export function NavSwitcherStates() {
+  return (
+    <div className="grid gap-8 sm:grid-cols-2">
+      <StateCard label="Collapse Hover">
+        <NavSwitcherMark direction="collapse" />
+      </StateCard>
+      <StateCard label="Expand Hover">
+        <NavSwitcherMark direction="expand" />
       </StateCard>
     </div>
   );

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -57,7 +57,8 @@ const ogImage = new URL(image ?? "/images/brand/profile-picture.jpg", siteConfig
         document.documentElement.classList.add("dark");
       }
 
-      if (localStorage.getItem("sidebar-collapsed") === "true") {
+      const sidebarPreference = localStorage.getItem("sidebar-collapsed");
+      if (sidebarPreference === null || sidebarPreference === "true") {
         document.documentElement.classList.add("sidebar-collapsed");
       }
     </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,10 +32,9 @@ const featuredProjectDescriptions: Record<string, string> = {
   vision: "Led strategic product vision work through facilitation, synthesis, and storytelling.",
 };
 
-const arcNodes = ["Strategist", "Developer", "Designer", "Writer", "Builder"];
-const heroHeadline = "The kind of designer who builds.";
-const heroIntro = "Hello, I'm Patrick. My career has never been one note. I've been a strategist, developer, designer, and writer — often all at once.";
-const heroIntroDetail = "What connects the work is a compulsion to turn ideas into useful, well-crafted things.";
+const heroHeadline = "Patrick is a designer who builds.";
+const heroIntro = "I've been a strategist, developer, designer, and writer — sometimes all at once.";
+const heroIntroDetail = "The through line is my compulsion to turn ideas into useful, well-crafted things.";
 const heroCurrentWorkLead = "Right now, I'm designing AI tools at";
 const heroCurrentWorkTail = "and building my own software with agents.";
 
@@ -88,42 +87,36 @@ const homeCardGrid = "grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 lg:ga
 <PageLayout>
 
   {/* ── Hero ────────────────────────────────────────────── */}
-  <section class={`${homeShell} pt-10 pb-4 sm:pt-16 sm:pb-10 lg:pt-16 lg:pb-6`}>
+  <section class={`${homeShell} pt-0 pb-4 sm:pb-10 md:pt-16 lg:pt-16 lg:pb-6`}>
 
     {/* Mobile layout */}
-    <div class="md:hidden">
-      <div class="mb-6 inline-block rotate-2 bg-white p-2 pb-5 shadow-xl shadow-black/15 transition-transform duration-300 hover:rotate-0 hover:scale-[1.02] dark:bg-[#20201e] dark:shadow-black/40" data-hero-photo style="opacity: 0;">
-        <div class="h-40 w-40 overflow-hidden">
-          <img
-            src="/images/brand/profile-living-room-avatar.jpg"
-            alt="Patrick Morgan"
-            class="block h-full w-full object-cover"
-          />
+    <div class="hero-mobile md:hidden">
+      <div class="hero-mobile-photo-field mb-8" data-hero-photo style="opacity: 0;">
+        <div class="hero-mobile-photo inline-block rotate-2 bg-white p-2 pb-5 shadow-xl shadow-black/15 transition-transform duration-300 hover:rotate-0 hover:scale-[1.02] dark:bg-[#20201e] dark:shadow-black/40">
+          <div class="h-36 w-36 overflow-hidden">
+            <img
+              src="/images/brand/profile-living-room-avatar.jpg"
+              alt="Patrick Morgan"
+              class="block h-full w-full object-cover"
+            />
+          </div>
         </div>
       </div>
       <PixelWaveText
         text={heroHeadline}
         as="h1"
         wave="hero"
-        class="mb-5 max-w-[20rem] text-[2.05rem] font-medium leading-[1.08] tracking-tight"
+        class="mb-7 max-w-[20rem] text-[2.05rem] font-medium leading-[1.08] tracking-tight"
         style="opacity: 0;"
       />
-      <div class="mb-6 flex max-w-[19rem] flex-wrap items-center gap-x-2 gap-y-2">
-        {arcNodes.map((label, i, arr) => (
-          <>
-            <span class:list={["arc-node rounded border px-2.5 py-1 font-mono text-xs", i === arr.length - 1 ? "arc-node-final" : ""]}
-              style={`animation-delay: ${i * 700}ms`}>{label}</span>
-          </>
-        ))}
-      </div>
-      <div class="mb-4 space-y-3 text-[15px] leading-relaxed">
+      <div class="mb-4 space-y-3 text-[15px] leading-relaxed" data-hero-desc style="opacity: 0;">
         <p class="text-foreground/80">{heroIntro}</p>
-        <p class="text-muted-foreground">{heroCurrentWorkLead} <a href="https://sublime.security" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 hover:text-accent">Sublime Security</a>, writing <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 hover:text-accent">Unknown Arts</a>, {heroCurrentWorkTail}</p>
+        <p class="text-muted-foreground">{heroCurrentWorkLead} <a href="https://sublime.security" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 hover:text-accent">Sublime Security</a>, writing my newsletter <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 hover:text-accent">Unknown Arts</a>, {heroCurrentWorkTail}</p>
       </div>
     </div>
 
     {/* Desktop: text left, photo right */}
-    <div class="hidden md:flex md:items-center md:gap-10 lg:gap-14">
+    <div class="hero-desktop hidden md:flex md:items-center md:gap-10 lg:gap-14">
 
       {/* Left — all text */}
       <div class="flex-1 min-w-0">
@@ -136,31 +129,20 @@ const homeCardGrid = "grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 lg:ga
           style="opacity: 0;"
         />
 
-        {/* Arc nodes */}
-        <div class="mb-8 flex flex-wrap items-center gap-1.5 sm:gap-2">
-          {arcNodes.map((label, i, arr) => (
-            <>
-              <span class:list={["arc-node rounded border px-2.5 py-0.5 font-mono text-[11px] sm:text-xs", i === arr.length - 1 ? "arc-node-final" : ""]}
-                style={`animation-delay: ${i * 700}ms`}>{label}</span>
-              {i < arr.length - 1 && <span class="font-mono text-xs text-muted-foreground/40">→</span>}
-            </>
-          ))}
-        </div>
-
         {/* Narrative */}
-        <div class="max-w-xl space-y-4 text-base leading-relaxed">
+        <div class="max-w-xl space-y-4 text-base leading-relaxed xl:max-w-2xl" data-hero-desc style="opacity: 0;">
           <p class="text-foreground/80">
             {heroIntro} {heroIntroDetail}
           </p>
           <p class="text-muted-foreground">
-            {heroCurrentWorkLead} <a href="https://sublime.security" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Sublime Security</a>, writing <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Unknown Arts</a>, {heroCurrentWorkTail}
+            {heroCurrentWorkLead} <a href="https://sublime.security" target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Sublime Security</a>, writing my newsletter <a href={siteConfig.social.newsletter} target="_blank" rel="noopener noreferrer" class="text-foreground underline underline-offset-4 transition-colors hover:text-accent">Unknown Arts</a>, {heroCurrentWorkTail}
           </p>
         </div>
 
       </div>
 
       {/* Right — polaroid photo */}
-      <div class="relative shrink-0 rotate-2 transition-transform duration-300 hover:rotate-0 hover:scale-[1.02]">
+      <div class="relative shrink-0 rotate-2 transition-transform duration-300 hover:rotate-0 hover:scale-[1.02]" data-hero-photo style="opacity: 0;">
         {/* Polaroid frame */}
         <button
           type="button"
@@ -207,13 +189,13 @@ const homeCardGrid = "grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 lg:ga
 
   {/* ── Work ─────────────────────────────────────────────── */}
   <section class={homeFirstSection}>
-    <div class={homeSectionHeader}>
+    <div class={homeSectionHeader} data-work-intro>
       <p class="font-mono text-xs uppercase tracking-widest text-muted-foreground">Work</p>
       <a href="/work" class="text-xs text-muted-foreground transition-colors hover:text-foreground">View all →</a>
     </div>
     <div class={homeCardGrid}>
       {professionalProjects.slice(0, 3).map((project, i) => (
-        <div data-project-card-item style="opacity: 0;">
+        <div data-project-card-item data-home-work-card style="opacity: 0;">
           <ProjectCard
             title={project.data.title}
             description={featuredProjectDescriptions[project.id] ?? project.data.description}
@@ -385,6 +367,89 @@ const homeCardGrid = "grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 lg:ga
   </section>
 
   <style>
+    .hero-mobile {
+      position: relative;
+      isolation: isolate;
+    }
+
+    .hero-mobile::before {
+      content: "";
+      position: absolute;
+      width: calc(100% + 3rem);
+      height: 15.5rem;
+      left: -1.5rem;
+      top: -0.75rem;
+      z-index: 0;
+      background-image: radial-gradient(currentColor 1px, transparent 1.5px);
+      background-size: 14px 14px;
+      color: var(--foreground);
+      opacity: 0.095;
+      mask-image: linear-gradient(to bottom, black 0%, black 30%, transparent 88%);
+    }
+
+    .hero-mobile > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    .hero-mobile-photo-field {
+      position: relative;
+      min-height: 12rem;
+      padding-top: 2.25rem;
+    }
+
+    .hero-mobile-photo {
+      position: relative;
+      z-index: 1;
+    }
+
+    html.dark .hero-mobile::before {
+      opacity: 0.1;
+    }
+
+    .hero-desktop {
+      position: relative;
+      isolation: isolate;
+    }
+
+    .hero-desktop > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    .hero-desktop::before {
+      content: "";
+      display: none;
+    }
+
+    @media (min-width: 48rem) {
+      .hero-desktop::before {
+        position: absolute;
+        display: block;
+        width: min(34rem, 40vw);
+        height: 26rem;
+        left: 80%;
+        top: 53%;
+        z-index: 0;
+        transform: translate(-50%, -50%) rotate(1deg);
+        background-image: radial-gradient(currentColor 1px, transparent 1.5px);
+        background-size: 14px 14px;
+        color: var(--foreground);
+        opacity: 0.105;
+        mask-image: radial-gradient(ellipse at 55% 54%, black 0%, black 52%, transparent 82%);
+      }
+    }
+
+    html.dark .hero-desktop::before {
+      opacity: 0.11;
+    }
+
+    @media (min-width: 48rem) {
+      [data-work-intro] {
+        opacity: 0;
+      }
+    }
+
     .builder-grid {
       background-image:
         linear-gradient(rgba(244, 238, 231, 0.12) 1px, transparent 1px),

--- a/src/pages/lab/pixel-mark.astro
+++ b/src/pages/lab/pixel-mark.astro
@@ -2,7 +2,7 @@
 import PageLayout from "@/layouts/PageLayout.astro";
 import Logo from "@/components/layout/Logo.astro";
 import { getCollection, render } from "astro:content";
-import { MarkStates, ScaleStrip, MarkVariants } from "@/lab/pixel-mark/MarkStates";
+import { MarkStates, NavSwitcherStates, ScaleStrip, MarkVariants } from "@/lab/pixel-mark/MarkStates";
 
 const entry = (await getCollection("lab")).find((item) => item.data.slug === "pixel-mark");
 if (!entry) throw new Error("Missing Lab entry: pixel-mark");
@@ -62,6 +62,19 @@ const { Content } = await render(entry);
     <div class="mx-auto max-w-3xl px-6 py-16">
       <h2 class="mb-10 font-mono text-xs uppercase tracking-widest text-muted-foreground">Interaction States</h2>
       <MarkStates client:load />
+    </div>
+  </section>
+
+  <!-- Production nav switcher -->
+  <section>
+    <div class="mx-auto max-w-3xl px-6 py-16">
+      <div class="mb-10 max-w-xl">
+        <h2 class="mb-3 font-mono text-xs uppercase tracking-widest text-muted-foreground">Navigation Switcher</h2>
+        <p class="text-sm leading-relaxed text-muted-foreground">
+          The sidebar uses the mark as a compact control. Its hover state previews whether the rail will collapse or expand.
+        </p>
+      </div>
+      <NavSwitcherStates client:load />
     </div>
   </section>
 </PageLayout>

--- a/src/pages/lab/pixel-wave.astro
+++ b/src/pages/lab/pixel-wave.astro
@@ -29,7 +29,7 @@ const { Content } = await render(entry);
     <p class="max-w-xl text-lg text-muted-foreground">{entry.data.description}</p>
   </section>
 
-  <section class="mx-auto max-w-3xl border-t border-border px-6 py-16" data-pixel-wave-demo data-lab-content style="opacity: 0">
+  <section class="mx-auto max-w-3xl px-6 pb-16" data-pixel-wave-demo data-lab-content style="opacity: 0">
     <div class="grid gap-8">
       <div class="relative flex min-h-[22rem] items-center justify-center rounded-lg border border-border bg-card px-6 py-16 text-center texture-bg">
         <PixelWaveText

--- a/src/scripts/home-animations.ts
+++ b/src/scripts/home-animations.ts
@@ -9,6 +9,14 @@ function springIn(el: HTMLElement, delay: number) {
   animate(el, { opacity: [0, 1], y: [16, 0] }, { ...spring, delay: delay / 1000 });
 }
 
+function softIn(el: HTMLElement, delay: number) {
+  animate(
+    el,
+    { opacity: [0, 1], y: [10, 0] },
+    { duration: 0.45, easing: "ease-out", delay: delay / 1000 }
+  );
+}
+
 // Immediately resolves pixel/sans layers without animation
 function resolvePixelWave(container: HTMLElement) {
   container.querySelectorAll<HTMLElement>("[data-pw-pixel]").forEach((el) => {
@@ -22,14 +30,18 @@ function resolvePixelWave(container: HTMLElement) {
 function init() {
   const seen = sessionStorage.getItem(SESSION_KEY);
 
-  const photo = document.querySelector("[data-hero-photo]") as HTMLElement | null;
-  const label = document.querySelector("[data-hero-label]") as HTMLElement | null;
-  const desc = document.querySelector("[data-hero-desc]") as HTMLElement | null;
-  const icons = document.querySelector("[data-hero-icons]") as HTMLElement | null;
-
   // On desktop (md+) animate the big headline wave; on mobile animate the name wave.
   // The other wave lives in a display:none block — resolve it silently so pixel font never flashes.
   const isMd = window.matchMedia("(min-width: 768px)").matches;
+  const activeHero = document.querySelector(isMd ? ".hero-desktop" : ".hero-mobile") as HTMLElement | null;
+  const photo = activeHero?.querySelector("[data-hero-photo]") as HTMLElement | null;
+  const label = activeHero?.querySelector("[data-hero-label]") as HTMLElement | null;
+  const desc = activeHero?.querySelector("[data-hero-desc]") as HTMLElement | null;
+  const icons = activeHero?.querySelector("[data-hero-icons]") as HTMLElement | null;
+  const workIntro = document.querySelector("[data-work-intro]") as HTMLElement | null;
+  const workCards = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-home-work-card]")
+  );
   const heroWave = document.querySelector(
     `[data-pixel-wave="${isMd ? "headline" : "hero"}"]`
   ) as HTMLElement | null;
@@ -38,6 +50,14 @@ function init() {
   ) as HTMLElement | null;
   if (inactiveWave) resolvePixelWave(inactiveWave);
 
+  function revealWorkPreview(startDelay: number) {
+    if (!isMd) return;
+    if (workIntro) softIn(workIntro, startDelay);
+    workCards.forEach((card, index) => {
+      springIn(card, startDelay + 110 + index * 90);
+    });
+  }
+
   function revealSections() {
     const sections = document.querySelectorAll(
       "[data-section-entrance]"
@@ -45,7 +65,13 @@ function init() {
     sections.forEach((section) => {
       animate(section, { opacity: [0, 1] }, { duration: 0.3, easing: "ease-out" });
     });
-    observeSections("[data-project-card-item]", { yOffset: 24, stagger: 0.1 });
+    observeSections(
+      isMd ? "[data-project-card-item]:not([data-home-work-card])" : "[data-project-card-item]",
+      {
+        yOffset: 24,
+        stagger: 0.1,
+      }
+    );
     observeSections("[data-kind-words-item]", { yOffset: 10, stagger: 0.04 });
   }
 
@@ -59,7 +85,8 @@ function init() {
     if (label) springIn(label, 60);
     if (desc) springIn(desc, 120);
     if (icons) springIn(icons, 180);
-    setTimeout(revealSections, 300);
+    revealWorkPreview(isMd ? 260 : 320);
+    setTimeout(revealSections, 520);
   } else {
     // First visit: full choreographed entrance
     sessionStorage.setItem(SESSION_KEY, "1");
@@ -70,12 +97,14 @@ function init() {
       // Make name visible immediately so pixel font shows while the wave cycles
       heroWave.style.opacity = "1";
       pixelWave(heroWave, 300);
-      if (desc) springIn(desc, 1200);
+      if (desc) springIn(desc, isMd ? 960 : 1200);
       if (icons) springIn(icons, 1350);
-      setTimeout(revealSections, 1500);
+      revealWorkPreview(isMd ? 1220 : 1500);
+      setTimeout(revealSections, isMd ? 1550 : 1500);
     } else {
       if (desc) springIn(desc, 240);
       if (icons) springIn(icons, 360);
+      revealWorkPreview(420);
       revealSections();
     }
   }


### PR DESCRIPTION
## Summary

- Default the desktop sidebar to the collapsed rail for first-time visitors and add clearer collapsed-state tooltips.
- Tighten the mobile navigation, rename Elsewhere to Links in the sidebar, and update homepage hero copy/spacing/animation.
- Add the portrait dot-grid treatment, remove hero arc nodes, document nav switcher states in the Pixel Mark lab, and align lab page spacing.

## Verification

- `pnpm build`
- Browser reload of `http://localhost:4321/` with no console errors
- Dev server kept running with `pnpm dev --host 0.0.0.0` for local-network testing